### PR TITLE
Remove link tweaking

### DIFF
--- a/_output.yml
+++ b/_output.yml
@@ -5,5 +5,3 @@ bookdown::bs4_book:
     bg: "#ffffff"
   repo: https://github.com/keaven/gsd-deming
   css: "style.css"
-  includes:
-    in_header: tweak-link.html

--- a/tweak-link.html
+++ b/tweak-link.html
@@ -1,7 +1,0 @@
-<script type="text/javascript">
-    window.onload = function () {
-        document.body.innerHTML = document.body.innerHTML.replace(/https:\/\/rdrr.io\/pkg\/gsDesign2\/man\//g, 'https://merck.github.io/gsDesign2/reference/');
-        document.body.innerHTML = document.body.innerHTML.replace(/https:\/\/rdrr.io\/pkg\/simtrial\/man\//g, 'https://merck.github.io/simtrial/reference/');
-        document.body.innerHTML = document.body.innerHTML.replace(/https:\/\/rdrr.io\/pkg\/gsdmvn\/man\//g, 'https://merck.github.io/gsdmvn/reference/');
-    }
-</script>


### PR DESCRIPTION
This PR removes the link tweaking JS which replaces the (incorrect) rdrr.io links for GitHub package functions when they were installed from local files - now they are installed from GitHub and rendered with the correct github.io documentation links so there is no need for this.

Removing this also fixes the search functionality, which wasn't working before potentially due to some conflicts in live replacing the page elements.