### PR TITLE
Fix format and typo

### DIFF
--- a/ahr.Rmd
+++ b/ahr.Rmd
@@ -100,7 +100,7 @@ By using the delta method (see details in [Dr. Lu Tian's slides](https://web.sta
   \forall i \in \{0, 1\}
 \end{equation}
 
-Withe the estimation of $\{\lambda_{i,m}\}_{i=0,1 \text{ and } m = 1, \ldots, M}$, it is not complicated to get the estimation and the asymptotic distribution of $HR_m$, which is defined as $HR_m = \lambda_{1,m}/\lambda_{0,m}$.
+With the estimation of $\{\lambda_{i,m}\}_{i=0,1 \text{ and } m = 1, \ldots, M}$, it is not complicated to get the estimation and the asymptotic distribution of $HR_m$, which is defined as $HR_m = \lambda_{1,m}/\lambda_{0,m}$.
 In this chapter, we are interested in the logarithm of $HR_m$ and denote it as $\beta_m$.
 Recall that
 \begin{equation}

--- a/background.Rmd
+++ b/background.Rmd
@@ -11,42 +11,40 @@ The detailed design can be referred to the [protocol](https://ars.els-cdn.com/co
 
 There are two interim analysis planned, one at 144 deaths (with information fraction as 0.42) and the other at 216 deaths (with information fraction as 0.64).
 The efficacy boundary is Hwang-Shih-DeCani (HSD) spending with $\gamma=-4$, and the futility boundary is non-binding $\beta$-spending HSD with $\gamma = -16$.
-The final analysis finds there are 388 deaths, compared with 340 planned death. 
+The final analysis finds there are 388 deaths, compared with 340 planned death.
 The 1-sided nominal p-value for OS at the final analysis is 0.0161.
 
 ```{r, echo=FALSE, fig.cap="KEYNOTE040",out.width = '100%'}
 knitr::include_graphics("./images/ahr_slides_KEYNOTE040.PNG")
 ```
 
-From the figure above, we can see there is a delay of the treatment effect. 
+From the figure above, we can see there is a delay of the treatment effect.
 
 The delayed effect is not just in oncology, it also lies in other TA.
-For example, in cholesterol lowering and mortality [@simva4s], there is also a delayed effect. 
+For example, in cholesterol lowering and mortality [@simva4s], there is also a delayed effect.
+
 ```{r, echo=FALSE, fig.cap="Scandinavian Simvistatin Survival Study", out.width = '80%'}
 knitr::include_graphics("./images/ahr_slides_SSSS.jpeg")
 ```
 
-
 In addition to delayed effect, NPH also exists when there is a cross over of survival curves.
-For example, in KEYNOTE061 (recurrent advanced gastric or gastro-oesophageal junction cancer), there is a cross over of the pembrolizumab arm and paclitaxel arm (see figure below). 
+For example, in KEYNOTE061 (recurrent advanced gastric or gastro-oesophageal junction cancer), there is a cross over of the pembrolizumab arm and paclitaxel arm (see figure below).
 It is 1:1 randomization with 360 planned events (395 actual events) at the end of the trial in CPS $\ge$ 1 population.
 The first primary endpoints is OS in PD-L1 CPS $\ge$ 1.
-Its power is 91\% for HR=0.67 with 1-sided $\alpha=0.0215$. 
+Its power is 91\% for HR=0.67 with 1-sided $\alpha=0.0215$.
 The secondary primary endpoints is PFS in PD-L1 CPS $\ge$ 1.
 The detailed design can be found in the  [protocol](https://ars.els-cdn.com/content/image/1-s2.0-S0140673618312571-mmc1.pdf)
 
 When it proceeded to final analysis, there are 326 deaths with 290 planned.
 One interim analysis is conducted with 240 events at information fraction of 0.83.
 During the group sequential design, the efficacy boundary is Hwang-Shih-DeCani (HSD) spending with $\gamma=-4$ and there is not a futility boundary.
-The 1-sided nominal p-value for OS is 0.0421 (threshold: p=0.0135). 
+The 1-sided nominal p-value for OS is 0.0421 (threshold: p=0.0135).
 And *Post hoc* FH($\rho=1,\gamma=1$) is  p=0.0009.
-
 
 KEYNOTE 061: Overall Survival in CPS 1
 ```{r, echo=FALSE, fig.cap="KEYNOTE061",out.width = '100%'}
 knitr::include_graphics("./images/ahr_slides_KEYNOTE061OS.PNG")
 ```
-
 
 The above two examples motivate us to think about following questions:
 
@@ -58,10 +56,9 @@ The above two examples motivate us to think about following questions:
 - Updating bounds
 - Multiplicity adjustments
 
-
 ### Group sequential design {#gsd}
 
-In group sequential design, groups of observations are collected and repeatedly analyzed, while controlling error rates. 
+In group sequential design, groups of observations are collected and repeatedly analyzed, while controlling error rates.
 While the group sequential design in ongoing, a stopping rule specifies when and why a trial might be halted at these points.
 This stopping rule usually consists two components, a test statistics and a threshold.
 The threshold is usually decided by the spending functions, which we introduced in Section \@ref(sf).
@@ -71,67 +68,65 @@ If a Z-process (B-process) cross the boundary, the the trail is stopped.
 ### Z-process and B-process
 
 In this Section, we will introduce the Z-process and B-process.
-Suppose in the group sequential design, there are totally $K$ looks. 
-In the $k$-th look, there are $n_k$ available observations. 
+Suppose in the group sequential design, there are totally $K$ looks.
+In the $k$-th look, there are $n_k$ available observations.
 For notation simplicity, we denote the final number of available observation as $N$, i.e., $N \triangleq n_K$.
 
 :::{.definition #DefZprocess}
 The Z-process is defined as the standardized treatment effect, i.e.,
-\begin{equation} 
-  Z_{k} 
-  = 
+\begin{equation}
+  Z_{k}
+  =
   \frac{\widehat\theta_k}{\sqrt{\hbox{Var}(\hat\theta_k)}},
   (\#eq:DefZprocess)
-\end{equation} 
+\end{equation}
 where $k$ is the index of the looks, and we assume there are totally $K$ number of looks, i.e., $k = 1, 2, \ldots, K$.
-The numerator $\widehat\theta_k$ is the treatment effect estimated at the $k$-th look. 
+The numerator $\widehat\theta_k$ is the treatment effect estimated at the $k$-th look.
 :::
 
 For $\widehat\theta_k$, its form depends on the outcome of the clinical trials.
-In clinical trails with continuous outcome $X_1, X_2, \ldots \in \mathbb R$, the treatment effect estimated at the $k$-th look is 
+In clinical trails with continuous outcome $X_1, X_2, \ldots \in \mathbb R$, the treatment effect estimated at the $k$-th look is
 \begin{equation}
-  \widehat{\theta}_k 
-  = 
+  \widehat{\theta}_k
+  =
   \frac{\sum_{i=1}^{n_k} X_{i}}{n_k}\equiv \bar X_{k},
   (\#eq:DefThetaK)
-\end{equation} 
+\end{equation}
 where $n_k$ is the number of available observations at the $k$-th look.
 In clinical trials with binary outcome  $X_1, X_2, \ldots \in \mathbb \{0, 1\}$, $\widehat\theta_k$ can be estimated the same as in equation \@ref(eq:DefThetaK).
-In clinical trials with survival outcome, $\widehat\theta_k$ would typically represent a Cox model coefficient representing the logarithm of the hazard ratio for experimental vs. control treatment. 
+In clinical trials with survival outcome, $\widehat\theta_k$ would typically represent a Cox model coefficient representing the logarithm of the hazard ratio for experimental vs. control treatment.
 And $n_k$ would represent the planned number of events at $k$-th look.
 
 After discussing the Z-process, let us take a look at the B-process.
 
 :::{.definition #DefBprocess}
-The B-process is defined as 
+The B-process is defined as
 \begin{equation}
   B_{k} = \sqrt{t_k} Z_k,
   (\#eq:DefBprocess)
 \end{equation}
-where $Z_k$ is defined in Definition \@ref(def:DefZprocess) and $t_k$ is the information fraction at the $k$-th look, i.e., 
+where $Z_k$ is defined in Definition \@ref(def:DefZprocess) and $t_k$ is the information fraction at the $k$-th look, i.e.,
 $$
   t_k = \mathcal I_k / \mathcal I_K,
 $$
-where $\mathcal I_k$ is the information at the $k$-th look, defined as 
+where $\mathcal I_k$ is the information at the $k$-th look, defined as
 $$
   \mathcal I_k \triangleq \frac{1}{\text{Var}(\widehat\theta_k)}.
 $$
 :::
 
-The information sequence plays an important role in the group sequential design. 
+The information sequence plays an important role in the group sequential design.
 For example, in a clinical trial with continuous outcome $X_1, X_2, \ldots \overset{i.i.d.}{\sim} N(\mu, \sigma^2)$, the information at the $k$-th look is $\mathcal I_k = n_k$ with $n_k$ as the number of available observations at the $k$-th look.
 The same logic applies to the binary outcome.
 Another example is a clinical trial with survival outcome. In this case, the information at the $k$-th look is $\mathcal I_k = n_k$ with $n_k$ as the number of events at the $k$-th look.
 
-
-
-### Canonical Form {#sec:EcfCf}
+### Canonical form {#sec:EcfCf}
 
 In the group sequential design, given the total $K$ look, there are sequences of Z-process and B-process, i.e., $\{Z_k\}_{k = 1, \ldots, K}$ and $\{B_k\}_{k = 1, \ldots, K}$.
 The CF refers to the joint distribution of $\{Z_k\}_{k = 1, \ldots, K}$ and $\{B_k\}_{k = 1, \ldots, K}$, including the distribution, the expectation mean, variance and covariance.
-Please note that this distribution is asymptotic, and the asymptotic conditions usually requires the sample size to be relative large. 
-Properly speaking, both $\{Z_k\}_{k = 1, \ldots, K}$ and $\{B_k\}_{k = 1, \ldots, K}$ depends on the sample size, which can be re-denoted as $\{ Z_{k,N} \}_{k = 1, \ldots, K}$ and $\{ B_{k, N} \}_{k = 1, \ldots, K}$. 
-When the sample size is relatively large, we can get rid of the sample size, i.e., 
+Please note that this distribution is asymptotic, and the asymptotic conditions usually requires the sample size to be relative large.
+Properly speaking, both $\{Z_k\}_{k = 1, \ldots, K}$ and $\{B_k\}_{k = 1, \ldots, K}$ depends on the sample size, which can be re-denoted as $\{ Z_{k,N} \}_{k = 1, \ldots, K}$ and $\{ B_{k, N} \}_{k = 1, \ldots, K}$.
+When the sample size is relatively large, we can get rid of the sample size, i.e.,
 $$
   Z_k = \lim\limits_{N \to \infty} Z_{k,N}.
 $$
@@ -140,11 +135,11 @@ This asymptotic assumed throughout this book.
 An important assumption of CF is $E(\widehat\theta_k) = \theta$, where $\theta$ is a constant and $\widehat\theta$ is defined in equation \@ref(eq:DefThetaK).
 
 ::: {.theorem #ThmZprocessDistCF}
-Suppose in a group sequential design, there are totally $K$ looks. 
-At the $k$-th look, there are $n_k$ available observations, i.e., $\{X_i\}_{i = 1, \ldots, n_k}$. 
+Suppose in a group sequential design, there are totally $K$ looks.
+At the $k$-th look, there are $n_k$ available observations, i.e., $\{X_i\}_{i = 1, \ldots, n_k}$.
 Assume that $\text{Var}(X_i) = 1$ for $i = 1, 2, \ldots, N$.
 And denote $\mathcal I_k \triangleq \frac{1}{\text{Var}(\widehat\theta(t_k))}$ and $E(\widehat\theta_k) = \theta$.
-The joint distribution of Z-process $\{Z_k\}_{k = 1, \ldots, K}$ is 
+The joint distribution of Z-process $\{Z_k\}_{k = 1, \ldots, K}$ is
 $$
 \left\{
 \begin{array}{l}
@@ -164,7 +159,7 @@ Following the similar, we can also summarize the distribution of B-process.
 
 ::: {.theorem #ThmBprocessDistCF}
 Following the same setting of Theorem \@ref(thm:ThmZprocessDistCF)
-The distribution of B-process is 
+The distribution of B-process is
 $$
 \left\{
 \begin{array}{l}
@@ -182,21 +177,21 @@ It should be noted that the correlation of B-process is the same as the covarian
 \begin{equation}
   Corr(B_i, B_j) = Cov(Z_i, Z_j) = \sqrt{t_i/t_j} \;\; \forall 1 \leq i \leq j \leq K.
 \end{equation}
-To learn this covariance/correlation better, let us take the continuous outcome as an example. 
+To learn this covariance/correlation better, let us take the continuous outcome as an example.
 Suppose there are $K$ looks in a clinical trial, and at the $k$-th look, there are $n_k$ available observations with outcome $\{ X_i \}_{i = 1, \ldots, n_k}$.
-In this example, we have 
-\begin{eqnarray} 
-  B_k 
-  & = & 
-  \sqrt{t_k} Z_k 
-  = 
-  \sqrt{\mathcal I_k / \mathcal I_K} \frac{\widehat\theta_k}{\sqrt{Var(\widehat\theta_k)}} 
+In this example, we have
+\begin{eqnarray}
+  B_k
+  & = &
+  \sqrt{t_k} Z_k
+  =
+  \sqrt{\mathcal I_k / \mathcal I_K} \frac{\widehat\theta_k}{\sqrt{Var(\widehat\theta_k)}}
   =
   \mathcal I_k\sqrt{ 1 / \mathcal I_K}  \widehat\theta_k \\
   & = &
   \mathcal I_k\sqrt{ 1 / \mathcal I_K}  \frac{\sum_{i=1}^{n_k} X_i}{n_k}
   =
-  \frac{\sum_{i=1}^{n_k} X_i}{\sqrt{I_K}} 
+  \frac{\sum_{i=1}^{n_k} X_i}{\sqrt{I_K}}
   =
   \frac{\sum_{i=1}^{n_k} X_i}{\sqrt{N}}.
 \end{eqnarray}
@@ -207,28 +202,27 @@ $$
 independent of $B_1, B_2, \ldots, B_i$.
 So we have
 \begin{eqnarray}
-  Corr(B_i, B_j) 
-  & = & 
+  Corr(B_i, B_j)
+  & = &
   Cov(B_i, B_j) \bigg / \sqrt{Var(B_i) Var(B_j)} \\
   & = &
   t_i \bigg / \sqrt{t_i t_j} = \sqrt{t_i / t_j}   \\
-  & = & 
+  & = &
   Cov(Z_i, Z_j)
 \end{eqnarray}
 
+### Extended canonical form {#sec:EcfEcf}
 
-### Extended Canonical Form {#sec:EcfEcf}
-
-The main difference between extended canonical form (ECF) and canonical form (CF) is that, ECF treats $E(\widehat\theta_k)$ as a time-varying parameter, i.e., $\theta(t_k)$. 
+The main difference between extended canonical form (ECF) and canonical form (CF) is that, ECF treats $E(\widehat\theta_k)$ as a time-varying parameter, i.e., $\theta(t_k)$.
 While CF treats it as a constant $\theta$.
 So we summarize the joint distribution of Z-process and B-process under ECF as follows
 
 ::: {.theorem #ThmZprocessDistCF}
-Suppose in a group sequential design, there are totally $K$ looks. 
-At the $k$-th look, there are $n_k$ available observations, i.e., $\{X_i\}_{i = 1, \ldots, n_k}$. 
+Suppose in a group sequential design, there are totally $K$ looks.
+At the $k$-th look, there are $n_k$ available observations, i.e., $\{X_i\}_{i = 1, \ldots, n_k}$.
 Assume that $\text{Var}(X_i) = 1$ for $i = 1, 2, \ldots, N$.
 And denote $\mathcal I_k \triangleq \frac{1}{\text{Var}(\widehat\theta(t_k))}$ and $E(\widehat\theta_k) = \theta(t_k)$.
-The joint distribution of Z-process $\{Z_k\}_{k = 1, \ldots, K}$ is 
+The joint distribution of Z-process $\{Z_k\}_{k = 1, \ldots, K}$ is
 $$
 \left\{
 \begin{array}{l}
@@ -257,7 +251,6 @@ If a statistics have the above distribution, we declare that it has the canonica
 ```{r, include=FALSE}
 # General multivariate normal theory and bound derivation from Yilong's WLR chapter.
 ```
-
 
 ## Spending function bounds {#sf}
 
@@ -325,6 +318,7 @@ where $c_P(K)$ is fixed given the number of total looks $K$ and chosen such that
 ```{r, echo=FALSE, fig.cap="Pocock boundary",out.width = '50%'}
 knitr::include_graphics("images/background_SF_Pocock_boundary.png")
 ```
+
 Here is an example of Pocock boundary.
 
 |total number of looks(K)| $\alpha = 0.01$ | $\alpha = 0.05$ | $\alpha = 0.1$ |
@@ -336,7 +330,6 @@ Here is an example of Pocock boundary.
 |$\infty$|$\infty$|$\infty$|$\infty$|
 
 We will reject $H_0$ if $|Z(k/4)| > 2.361$ for $k = 1,2,3,4$ (final analysis).
-
 
 In summary, the Pocock boundary is a special case of Wang-Tsiatis boundary ($\Delta = 0.5$) and has constant Z-score boundaries, i.e., $|Z(k/K)| > c_P(K)$.
 And the constant boundary $c_P(K)$ is decided by the type I error rate and the total number of looks.
@@ -386,8 +379,8 @@ knitr::include_graphics("images/background_SF_OF_P_t.png")
 
 The second difference is that, they have different performance in cumulative type I error rate (the probability of rejection at or before $t_j$, i.e., $\text{Pr}(\cup_{i=1}^j |Z(t_i)| > c_i)$).
 
-  - The Pocock cumulative type I error rate increases sharply at first, but much less so toward the end.
-  - The O'Brien-Fleming behaves in just the opposite way.
+- The Pocock cumulative type I error rate increases sharply at first, but much less so toward the end.
+- The O'Brien-Fleming behaves in just the opposite way.
 
 ```{r, echo=FALSE, fig.cap="Cumulative type 1 error rate used by the Pocock (circles) and O'Brien-Fleming (squares) procedures with four looks.",out.width = '50%'}
 knitr::include_graphics("images/background_SF_cumType1_t.png")
@@ -460,4 +453,3 @@ Comparing survival outcome and continuous/binary outcome, we found the informati
 
 If there are multiple interim analysis at $\tau_1$-th, $\tau_2$-th, $\ldots$, $\tau_K$-th month, we get a sequence of information as $I(\tau_1), I(\tau_2), \ldots, I(\tau_K)$ and a sequence of information fraction $t_1, t_2, \ldots, t_K$.
 Please note that, the information sequence is sometimes simplified as $I_1, I_2, \ldots, I_K$ [@JTBook].
-

--- a/fixed-design.Rmd
+++ b/fixed-design.Rmd
@@ -14,7 +14,7 @@ For fixed design, [`npsurvSS`](https://cran.r-project.org/package=npsurvSS)
 will be the tool for this training.
 :::
 
-The fixed design part is largely follow the concept described in @yung2019sample.
+The fixed design part largely follows the concept described in @yung2019sample.
 
 ## Summary of assumptions
 
@@ -113,7 +113,7 @@ stats::power.t.test(delta = 0.5, sd = 2, sig.level = 0.05, power = 0.8)$n * 2
 Let's also explore the number of events required for logrank test under the proportional hazards assumption.
 
 You may hear the sample size calculation is "event-driven".
-This is a nice feature under the **proportional hazards assumption**. because the effect size for number of events is only depends on the hazard ratio.
+This is a nice feature under the **proportional hazards assumption** because the effect size for number of events is only depends on the hazard ratio.
 
 $$\theta = \log{\text{HR}} / 2$$
 
@@ -143,7 +143,7 @@ For simplicity, we skip the detail of sample size calculation,
 interested readers can refer @lachin1986evaluation.
 :::
 
-Let's make connection between math formula and R code by considering a scenarios with
+Let's make connection between math formula and R code by considering a scenario with
 hazard ratio at 0.6.
 
 ```{r}
@@ -185,8 +185,8 @@ npsurvSS::size_two_arm(arm0, arm1,
 )
 ```
 
-The number of events from `gsDesign::nSurv()` is slighted smaller,
-because, `gsDesign::nSurv()` follows @lachin1986evaluation
+The number of events from `gsDesign::nSurv()` is slightly smaller
+because `gsDesign::nSurv()` follows @lachin1986evaluation
 that relax the local alternative assumption and is recommended in practice.
 
 ```{r}
@@ -228,9 +228,9 @@ knitr::include_graphics("images/ch2_n_to_d.svg")
 The two figures above are copied from @yung2019sample.
 :::
 
-Let's considered a delay effect scenario below to illustrate NPH and sample size calculation.
+Let's consider a delayed effect scenario below to illustrate NPH and sample size calculation.
 
-- Duration of enrollment: 12 month
+- Duration of enrollment: 12 months
 - Enrollment rate: 500/12 per month
 
 ```{r}
@@ -239,10 +239,10 @@ enrollRates
 ```
 
 - Failure rate in control group: `log(2) / 15`
-  + Median survival time: 15 months.
+  - Median survival time: 15 months.
 - Hazard ratio:
-  + First 4 months: 1
-  + After 4 months: 0.6
+  - First 4 months: 1
+  - After 4 months: 0.6
 - Dropout Rate: 0.001
 
 ```{r}
@@ -325,7 +325,7 @@ npsurvSS::size_two_arm(arm0, arm1,
 
 ### Effect size
 
-In Yung and Liu (2019), section 2.3.3, it is shown that， the test statistics $Z\rightarrow_d\mathcal{N}(\sqrt{n}\theta, 1)$ approximately,
+In @yung2019sample, section 2.3.3, it is shown that, the test statistics $Z\rightarrow_d\mathcal{N}(\sqrt{n}\theta, 1)$ approximately,
 where $\theta = \Delta/\sigma$ is the effect size. Here the test statistics for weighted logrank test is:
 
 $$ Z=\sqrt{\frac{n_{0}+n_{1}}{n_{0}n_{1}}}\int_{0}^{\tau}w(t)\frac{\overline{Y}_{0}(t)\overline{Y}_{1}(t)}{\overline{Y}_{0}(t)+\overline{Y}_{0}(t)}\left\{ \frac{d\overline{N}_{1}(t)}{\overline{Y}_{1}(t)}-\frac{d\overline{N}_{0}(t)}{\overline{Y}_{0}(t)}\right\} $$
@@ -353,7 +353,7 @@ sigma2 <- gsdmvn:::gs_sigma2_wlr(arm0, arm1, tmax = arm0$total_time, weight = we
 sigma2
 ```
 
-Below are definitions of each components.
+Below are definitions of each component.
 
 - $n = n_0 + n_1$: Total sample size
 - $p_0 = n_0/n$, $p_1 = n_1/n$: Randomization probability inferred by randomization ratio
@@ -469,6 +469,7 @@ plot(x, 1 - pexp(x),
 - $E\{N(t)\}$: expected probability of events
 
 $$E\{N(t)\} = \int_{0}^{t}f_{T}(s)S_{L}(s)F_{R}(\tau_{a}\land(\tau-s))ds$$
+
 ```{r}
 # Probability of Events
 x_int <- 0:arm0$total_time
@@ -566,6 +567,7 @@ plot(t, exp(log_ahr),
 it can be simplified to
 
 $$\log(AHR) = \frac{\sum d_i \log{HR_i}}{\sum d_i}$$
+
 ```{r}
 gsDesign2::AHR(enrollRates, failRates, totalDuration = arm0$total_time)
 ```
@@ -664,7 +666,7 @@ corr_combo
 The formula to calculate sample size based on effect size does not directly apply,
 because the test statistic for MaxCombo is not asymptotically normal.
 
-The type I Error shall be:
+The type I Error should be:
 
 $$\alpha = \text{Pr}(\max(Z_1, Z_2) > z_{\alpha} \, | \, H_0) = 1 - \text{Pr}(Z_1 < z_{\alpha}, Z_2 < z_{\alpha} \, | \, H_0)$$
 
@@ -675,7 +677,7 @@ z_alpha <- qmvnorm(p = 1 - 0.025, corr = corr_combo)
 z_alpha$quantile
 ```
 
-The power shall be
+The power should be
 
 $$\beta = \text{Pr}(\max(Z_1, Z_2) > z_{\alpha} \, | \, H_1) = 1 - \text{Pr}(Z_1 < z_{\alpha}, Z_2 < z_{\alpha} \, | \, H_1)$$
 

--- a/maxcombo-boundary.Rmd
+++ b/maxcombo-boundary.Rmd
@@ -248,8 +248,8 @@ $$ = \text{Pr}(\cap_{i=1}^{i=k-1} G_i < b_i \mid H_0) - \text{Pr}(\cap_{i=1}^{i=
 gsdmvn:::gs_bound(alpha_spend, beta_spend,
   analysis = utility$info$Analysis, # Analysis indicator
   theta = rep(0, nrow(fh_test)), # Under the null hypothesis
-  corr = utility$corr
-)$upper # Correlation
+  corr = utility$corr # Correlation
+)$upper
 ```
 
 - Compared with upper bound calculated from `gsDesign`
@@ -310,8 +310,8 @@ utility <- gsdmvn:::gs_utility_combo(enrollRates, failRates, fh_test = fh_test, 
 bound <- gsdmvn:::gs_bound(alpha_spend, beta_spend,
   analysis = utility$info$Analysis, # Analysis indicator
   theta = utility$theta * sqrt(n), # Under the alternative hypothesis
-  corr = utility$corr
-) # Correlation
+  corr = utility$corr # Correlation
+)
 
 bound$lower
 ```
@@ -353,8 +353,8 @@ utility <- gsdmvn:::gs_utility_combo(enrollRates, failRates, fh_test = fh_test, 
 bound <- gsdmvn:::gs_bound(alpha_spend, beta_spend,
   analysis = utility$info$Analysis, # Analysis indicator
   theta = utility$theta * sqrt(n), # Under the alternative hypothesis
-  corr = utility$corr
-) # Correlation
+  corr = utility$corr # Correlation
+)
 
 bound
 ```

--- a/maxcombo.Rmd
+++ b/maxcombo.Rmd
@@ -17,11 +17,11 @@ In this chapter, we discuss group sequential design for MaxCombo test.
 
 $$ Z_{ik}=\sqrt{\frac{n_{0}+n_{1}}{n_{0}n_{1}}}\int_{0}^{t_k}w_i(t)\frac{\overline{Y}_{0}(t)\overline{Y}_{1}(t)}{\overline{Y}_{0}(t)+\overline{Y}_{0}(t)}\left\{ \frac{d\overline{N}_{1}(t)}{\overline{Y}_{1}(t)}-\frac{d\overline{N}_{0}(t)}{\overline{Y}_{0}(t)}\right\} $$
 
-- Not necessary to have same number of tests in each interim analysis
+- Not necessary to have the same number of tests in each interim analysis
 
 ## Examples
 
-We continue use the same example scenario in the last chapter.
+We continue to use the same example scenario from the last chapter.
 
 ```{r, include=FALSE}
 enrollRates <- tibble::tibble(Stratum = "All", duration = 12, rate = 500 / 12)
@@ -54,15 +54,15 @@ analysisTimes <- c(12, 24, 36)
 # Define study design object in each arm
 gs_arm <- gsdmvn:::gs_create_arm(enrollRates, failRates,
   ratio = 1, # Randomization ratio
-  total_time = 36
-) # Total study duration
+  total_time = 36 # Total study duration
+)
 arm0 <- gs_arm[["arm0"]]
 arm1 <- gs_arm[["arm1"]]
 ```
 
 ### Example 1
 
-- Using logrank test in all interim analysis and a MaxCombo test $Z_{1k}: FH(0,0)$, $Z_{2k}: FH(0,0.5)$, $Z_{3k}: FH(0.5,0.5)$ in final analysis.
+- Using logrank test in all interim analyses and a MaxCombo test $Z_{1k}: FH(0,0)$, $Z_{2k}: FH(0,0.5)$, $Z_{3k}: FH(0.5,0.5)$ in final analysis.
 
 ```{r}
 fh_test1 <- rbind(
@@ -97,9 +97,9 @@ fh_test2
 
 ## Sample size calculation
 
-We first consider a user defined lower and upper bound using `gsDesign` bound
+We first consider a user-defined lower and upper bound using `gsDesign` bound
 
-In general, `gsDesign` bound can not be directly used for MaxCombo test:
+In general, `gsDesign` bound cannot be directly used for MaxCombo test:
 
 - Multiple test statistics are considered in interim analysis or final analysis.
 
@@ -128,7 +128,7 @@ x$lower$bound
 
 ### Example 1
 
-Sample size can be calculated using `gsdmvn::gs_design_combo`.
+Sample size can be calculated using `gsdmvn::gs_design_combo()`.
 
 ```{r}
 gsdmvn::gs_design_combo(enrollRates,
@@ -231,7 +231,7 @@ gsdmvn::gs_design_wlr(
 
 ## Outline of technical details
 
-We described the details of calculating
+We describe the details of calculating
 the sample size and events required for WLR under fixed design.
 
 It can be skipped for the first read of this training material.
@@ -388,7 +388,7 @@ corr_combo1 <- corr_combo
 corr_combo1 %>% round(2)
 ```
 
-- Compared with Simulation results based on 10,000 replications.
+- Compared with simulation results based on 10,000 replications.
 
 ```{r, echo = FALSE}
 plot(corr_combo1, corr_combo1 - corr1,
@@ -421,7 +421,7 @@ corr_combo2 <- corr_combo
 corr_combo2 %>% round(2)
 ```
 
-- Compared with Simulation results based on 10,000 replications.
+- Compared with simulation results based on 10,000 replications.
 
 ```{r, echo = FALSE}
 plot(corr_combo2, corr_combo2 - corr2,

--- a/pkgs.Rmd
+++ b/pkgs.Rmd
@@ -7,33 +7,33 @@ Below is the Github repo link to the source code
 - `gsDesign2`: <https://github.com/Merck/gsDesign2>
 - `gsdmvn`: <https://github.com/Merck/gsdmvn>
 
-## `simtrial` 
+## `simtrial`
 
 The R package `simtrial` targets on time-to-event trial simulation under the piecewise model.
 It uses logrank and weighted logrank for analysis.
-It can simulates both fixed and group sequential design, also potential to simulate adaptive design.
-Its validation near completion (thanks to AP colleagues and Amin Shirazi).
+It can simulate both fixed and group sequential design, also potential to simulate adaptive design.
+Its validation is near completion (thanks to AP colleagues and Amin Shirazi).
 
 In `simtrial`, there are several functions to generate simulated datasets:
 
 - `simfix()`: Simulation of fixed sample size design for time-to-event endpoint
-- `simfix2simPWSurv()`: Conversion of enrollment and failure rates from simfix() to simPWSurv() format
+- `simfix2simPWSurv()`: Conversion of enrollment and failure rates from `simfix()` to `simPWSurv()` format
 - `simPWSurv()`: Simulate a stratified time-to-event outcome randomized trial
 
 There are also functions to cut data for analysis:
 
-- `cutData()`: Cut a Dataset for Analysis at a Specified Date
-- `cutDataAtCount()`: Cut a Dataset for Analysis at a Specified Event Count
-- `getCutDateForCount()`: Get Date at Which an Event Count is Reached
+- `cutData()`: Cut a dataset for analysis at a specified date
+- `cutDataAtCount()`: Cut a dataset for analysis at a specified event count
+- `getCutDateForCount()`: Get date at which an event count is reached
 
 Most importantly, there are functions for analysis:
 
-- `tenFH()`: Fleming-Harrington Weighted Logrank Tests
-- `tenFHcorr()`: Fleming-Harrington Weighted Logrank Tests plus Correlations
-- `tensurv()`: Process Survival Data into Counting Process Format
+- `tenFH()`: Fleming-Harrington weighted logrank tests
+- `tenFHcorr()`: Fleming-Harrington weighted logrank tests plus correlations
+- `tensurv()`: Process survival data into counting process format
 - `pMaxCombo()`: MaxCombo p-value
 - `pwexpfit()`: Piecewise exponential survival estimation
-- `wMB()`: Magirr and Burman Modestly Weighted Logrank Tests
+- `wMB()`: Magirr and Burman modestly weighted logrank tests
 
 In `simtrial`, there are reverse engineered datasets:
 
@@ -47,7 +47,7 @@ In `simtrial`, there are reverse engineered datasets:
 
 ## `gsDesign2`
 
-The R package `gsDesigns` has the main functions listed as follows.
+The R package `gsDesign2` has the main functions listed as follows.
 
 - `AHR()`: Average hazard ratio under non-proportional hazards (test version)
 - `eAccrual()`: Piecewise constant expected accrual
@@ -56,28 +56,25 @@ The R package `gsDesigns` has the main functions listed as follows.
 - `s2pwe()`: Approximate survival distribution with piecewise exponential distribution
 - `tEvents()`: Predict time at which a targeted event count is achieved
 
-
 ## `gsdmvn`
 
 The R package `gsdmvn` extends the @JTBook computational model to non-constant treatment effects.
 The bound supports functions include
 
-- `gsb()`: direct input of bounds;
+- `gs_b()`: direct input of bounds;
 - `gs_spending_bound()`: spending function bounds.
-
 
 Besides, it covers three models for analysis.
 
-- average hazard ratio model (see detailed description in Section \@ref(secAhr))
-  + `gs_power_ahr()`: Power computation
-  + `gs_design_ahr()`: Design computations
-- weighted logrank model (see detailed description in Section \@ref(wlr))
-  + `gs_power_wlr()`: Power computation
-  + `gs_design_wlr()`: Design computations 
-- max combo model (see detailed description in Section \@ref(maxcombo))
-  + `gs_power_combo()`: Power computation
-  + `gs_design_combo()`: Design computations
-
+- Average hazard ratio model (see detailed description in Section \@ref(secAhr))
+  - `gs_power_ahr()`: Power computation
+  - `gs_design_ahr()`: Design computations
+- Weighted logrank model (see detailed description in Section \@ref(wlr))
+  - `gs_power_wlr()`: Power computation
+  - `gs_design_wlr()`: Design computations
+- MaxCombo model (see detailed description in Section \@ref(maxcombo))
+  - `gs_power_combo()`: Power computation
+  - `gs_design_combo()`: Design computations
 
 ## Simulation
 
@@ -106,6 +103,7 @@ library(gsDesign)
 library(simtrial)
 library(dplyr)
 library(gsdmvn)
+
 ## Set the enrollment rates
 my_enrollRates <- tibble::tibble(
   Stratum = "All",
@@ -200,8 +198,10 @@ library(gsDesign)
 library(simtrial)
 library(dplyr)
 library(gsdmvn)
+
 load("./data/simulation_gs_power_ahr_my_simfix.Rdata")
 load("./data/simulation_gs_power_ahr_my_gsDesign.Rdata")
+
 ## Set the enrollment rates
 my_enrollRates <- tibble::tibble(
   Stratum = "All",
@@ -278,7 +278,6 @@ my_failRates <- tibble(
   hr = c(1, 0.6),
   dropoutRate = 0.001
 )
-
 
 # Set number of simulations
 my_nsim <- 10

--- a/proportional-hazards.Rmd
+++ b/proportional-hazards.Rmd
@@ -8,7 +8,7 @@ if you copy the repository to your local PC, you will be able to easily access t
 After a brief review of methodology, we recreate designs and evaluate final inference for multiple published trials:
 
 - We begin with the KEYNOTE 189 trial [@KEYNOTE189] to show a straightforward, common application in metastatic (high-risk) cancer.
-- We proceeed to the AFCAPS/TEXCAPS trial [@AFCAPSdesign] [@AFCAPSresults], a cardiovascular endpoint trial with much lower risk than a metastatic oncology trial.
+- We proceed to the AFCAPS/TEXCAPS trial [@AFCAPSdesign] [@AFCAPSresults], a cardiovascular endpoint trial with much lower risk than a metastatic oncology trial.
 - Next we look at the EXAMINE trial [@EXAMINEresults], a trial in diabetic patients evaluating a non-inferiority hypothesis for cardiovascular outcomes.
 
 We also create a design for a hypothetical trial in oncology where a long-term plateau in endpoints is likely. We approach this with a proportional hazards cure model.
@@ -25,8 +25,7 @@ The number of events drives power, regardless of study duration, as noted by @Sc
 
 One place where we deviate from the Lachin and Foulkes method is when we approximate the hazard ratio at study bounds.
 This should always be considered an approximation that is informative to those reviewing the design rather than a requirement to cross a bound.
-In any case, the approximation is that of @Schoenfeld1981 which is quite simple and implemented in the function `gsDesign::gsHR()`. 
-
+In any case, the approximation is that of @Schoenfeld1981 which is quite simple and implemented in the function `gsDesign::gsHR()`.
 
 ## Metastatic oncology example {#mediansurvival}
 
@@ -58,6 +57,7 @@ The design is derived as:
 library(gsDesign)
 library(dplyr)
 library(gt)
+
 KEYNOTE189design <- gsSurv(
   # Number of analyses
   k = 3,
@@ -120,7 +120,6 @@ We further describe the information in this table as follows:
 - P(Cross) if HR =`r round(KEYNOTE189design$hr, 3)` is the cumulative probability of crossing
   a bound under the alternate hypothesis.
 
-
 The design is updated at the interim analysis with 235 deaths as follows.
 The code can be written by the app for you, this is provided only if you wish to dive into details.
 We note that the function `gsDesign()` is used for the update while `gsSurv()` was used for the original design.
@@ -142,25 +141,28 @@ xu <- gsDesign(
   sfl = x$lower$sf, sflpar = x$lower$param,
   delta = x$delta, delta1 = x$delta1, delta0 = x$delta0
 )
+
 # Now we summarize bounds in a table
 xu %>%
   gsBoundSummary(
-  deltaname = "HR", # Name of treatment difference measure
-  logdelta = TRUE,  # For survival, delta is on a log scale; this transforms
-  Nname = "Events", # "N" for analyses is events for survival analysis
-  digits = 5,       # decimals for numbers in body of table
-  ddigits = 2,      # decimals for natural parameter; HR in this case
-  tdigits = 1,      # Time digits (not needed here)
-  # We select key parameters for printing
-  exclude = c(
-    "B-value", "CP", "CP H1", "PP",
-    paste0("P(Cross) if HR=", round(c(x$hr0, x$hr), digits = 2))
-  )
+    deltaname = "HR", # Name of treatment difference measure
+    logdelta = TRUE, # For survival, delta is on a log scale; this transforms
+    Nname = "Events", # "N" for analyses is events for survival analysis
+    digits = 5, # decimals for numbers in body of table
+    ddigits = 2, # decimals for natural parameter; HR in this case
+    tdigits = 1, # Time digits (not needed here)
+    # We select key parameters for printing
+    exclude = c(
+      "B-value", "CP", "CP H1", "PP",
+      paste0("P(Cross) if HR=", round(c(x$hr0, x$hr), digits = 2))
+    )
   ) %>%
-  gt() %>% tab_header(title = "Updated bounds for interim analysis",
-                      subtitle = "KEYNOTE 189 trial")
+  gt() %>%
+  tab_header(
+    title = "Updated bounds for interim analysis",
+    subtitle = "KEYNOTE 189 trial"
+  )
 ```
-
 
 The p-value reported at interim 1 was <0.001 [@KEYNOTE189], establishing statistical significance relative to the bound of 0.00128 in the summary table above as well as in the publication.
 
@@ -188,7 +190,6 @@ More parameters than needed are given than sometimes needed when code is generat
 Comments indicate where this is the case.
 Code and comments are largely copied from the app, so this may help the reader interpret what they see there.
 
-
 ```{r, message=FALSE}
 # Number of analyses
 k <- 3
@@ -208,7 +209,7 @@ timing <- c(0.375, 0.75)
 sfu <- sfHSD
 # Upper bound spending function parameters, if any
 sfupar <- -4
-# NOTE THAT THE NEXT 2 PARAMETERS ARE NOT NEEDED AS THE 
+# NOTE THAT THE NEXT 2 PARAMETERS ARE NOT NEEDED AS THE
 # LOWER BOUND WAS SPECIFIED IN sfu and sfupar SINCE test.type=2 was specified.
 # Lower bound spending function, if used (test.type > 2)
 sfl <- sfLDOF
@@ -246,9 +247,10 @@ Now we plug the above parameters into `gsSurv()` to generate the design.
 See comments above for interpretation of the parameters.
 
 ```{r, message = FALSE}
-x <- gsSurv(k = k, test.type = test.type, alpha = alpha, beta = beta, 
-  astar = astar, timing = timing, sfu = sfu, sfupar = sfupar, sfl = sfl, 
-  sflpar = sflpar, lambdaC = lambdaC, hr = hr, hr0 = hr0, eta = eta, 
+x <- gsSurv(
+  k = k, test.type = test.type, alpha = alpha, beta = beta,
+  astar = astar, timing = timing, sfu = sfu, sfupar = sfupar, sfl = sfl,
+  sflpar = sflpar, lambdaC = lambdaC, hr = hr, hr0 = hr0, eta = eta,
   gamma = gamma, R = R, S = S, T = T, minfup = minfup, ratio = ratio
 )
 ```
@@ -256,7 +258,7 @@ x <- gsSurv(k = k, test.type = test.type, alpha = alpha, beta = beta,
 The reader can see summaries of the above with following commands which we do not run here:
 
 ```{r, eval = FALSE}
-summary(x)        # Textual summary of design
+summary(x) # Textual summary of design
 gsBoundSummary(x) # Tabular summary of design
 ```
 
@@ -269,6 +271,7 @@ This is not required, but can limit misinterpretations.
 ```{r}
 x$n.I # Events at planned analyses
 ```
+
 Here are the nominal 1-sided p-value bounds which could also be seen with the `gsBoundSummary(x)` command above.
 
 ```{r}
@@ -279,7 +282,7 @@ Doubling these 1-sided bounds, we can compare to bounds from @AFCAPSdesign: *The
 
 From @AFCAPSresults we have *After an average follow-up of 5.2 years, lovastatin reduced the incidence of first acute major coronary events (183 vs 116 first events; relative risk [RR], 0.63; 95% confidence interval [CI], 0.50-0.79; P<.001).` This was at the second interim analysis. We see immediately that the 299 events were less than the second planned analysis after 332 events.
 The bounds are easily adapted in the app. We provide the code generated with the design update provided by the app. We assumed the first interim was performed with the planned 240 events.
-First, we enter the updated event counts. 
+First, we enter the updated event counts.
 
 ```{r}
 n.I <- c(120, 299, 320)
@@ -298,15 +301,15 @@ Note that we are now using `gsDesign()` rather than `gsSurv()` as calendar time 
 ```{r}
 xu <- gsDesign(
   # Updated parameters
-  k = ku, # Number of analyses 
-  n.I = n.I,  # Number of events
-  # Spending time; you don't really need this if you are just using 
+  k = ku, # Number of analyses
+  n.I = n.I, # Number of events
+  # Spending time; you don't really need this if you are just using
   # information (event) fraction
   usTime = usTime,
   lsTime = lsTime,
   # Remaining parameters from original design
-  test.type = x$test.type, alpha = x$alpha, beta = x$beta, 
-  astar = x$astar, sfu = x$upper$sf, sfupar = x$upper$param, 
+  test.type = x$test.type, alpha = x$alpha, beta = x$beta,
+  astar = x$astar, sfu = x$upper$sf, sfupar = x$upper$param,
   sfl = x$lower$sf, sflpar = x$lower$param,
   # maxn.IPlan is key for update to set max planned information
   maxn.IPlan = x$n.I[x$k],
@@ -324,20 +327,23 @@ You can see how much this changes by trying different event counts in the update
 ```{r, message = FALSE}
 library(dplyr)
 library(gt)
+
 gsBoundSummary(
   xu, # Updated design
   deltaname = "HR", # Name of treatment difference measure
-  logdelta = TRUE,  # For survival, delta is on a log scale; this transforms
+  logdelta = TRUE, # For survival, delta is on a log scale; this transforms
   Nname = "Events", # "N" for analyses is events for survival analysis
-  digits = 4,       # decimals for numbers in body of table
-  ddigits = 2,      # decimals for natural parameter; HR in this case
-  tdigits = 1,      # Time digits (not needed here)
+  digits = 4, # decimals for numbers in body of table
+  ddigits = 2, # decimals for natural parameter; HR in this case
+  tdigits = 1, # Time digits (not needed here)
   # We select key parameters for printing
   exclude = c(
     "B-value", "CP", "CP H1", "PP",
     paste0("P(Cross) if HR=", round(c(hr0, hr), digits = 2))
   )
-) %>% gt() %>% tab_header(title="Updated AFCAPS bounds at IA 2")
+) %>%
+  gt() %>%
+  tab_header(title = "Updated AFCAPS bounds at IA 2")
 ```
 
 ## Cardiovascular outcomes non-inferiority
@@ -361,7 +367,6 @@ endpoint MACE stratified by geographic region and screening renal function.
   - 4.75 years trial duration.
   - 1\% annual loss-to-follow-up rate.
   - Software: EAST 5 (Cytel).
-
 
 ```{r}
 EXAMINEdesign <- gsSurv(
@@ -420,7 +425,7 @@ n.I <- c(621, 650)
 ku <- length(n.I)
 # This is just specifying event fraction vs final planned
 # is used for computing spending.
-# If calendar spending were specified, calendar fraction 
+# If calendar spending were specified, calendar fraction
 # would be used here.
 usTime <- n.I / EXAMINEdesign$n.I[x$k]
 lsTime <- usTime
@@ -468,7 +473,9 @@ gsBoundSummary(
   ddigits = 2,
   tdigits = 1,
   exclude = c(
-    "B-value", "CP", "CP H1", "PP")) %>%
+    "B-value", "CP", "CP H1", "PP"
+  )
+) %>%
   gt() %>%
   tab_header(
     title = "EXAMINE trial design",
@@ -482,7 +489,6 @@ See the following link for the Moderna COVID-19 design replication: <https://med
 
 Can you reproduce this using the Shiny interface?
 
-
 ## Cure model {#poissonmixture}
 
 We consider a Poisson mixture model @deCastroGAMLSS which has also been referred to as a transformation cure model @Zhang2018 or promotion time cure model @Zeng2006.
@@ -495,7 +501,6 @@ Part of the suggested rationale is that the trial needs to be completed in a cer
 Much simpler models such as a 2- or 3-piece piecewise exponential model could be equally effective for a design of this nature, so this is just one example of an approach to a situation of this nature.
 This is our longest example; a simpler version of this is demonstrated in the app.
 Readers not immediately interested in the approach can simply skip the rest of this chapter.
-
 
 ### Cure model parameters
 

--- a/slides/01-s-outline.Rmd
+++ b/slides/01-s-outline.Rmd
@@ -29,8 +29,8 @@ This is also available at <https://gsdesign.shinyapps.io/prod/>, but this site i
 ## Course resources
 
 - Book at <https://keaven.github.io/gsd-deming/>
-    - Instructions there to install software, download repositories at <https://github.com/keaven/gsd-deming>
+    - Instructions there to install software, download repository at <https://github.com/keaven/gsd-deming>
     - Directories there we will use:
-        - data: contains design files for examples; also simulation results
-        - vignettes: reports produced by Shiny app to summarize designs
-        - simulation: R code and simulation data for last part of course
+        - `data/`: contains design files for examples; also simulation results
+        - `vignettes/`: reports produced by Shiny app to summarize designs
+        - `simulation/`: R code and simulation data for the last part of course

--- a/slides/02-s-background.Rmd
+++ b/slides/02-s-background.Rmd
@@ -4,7 +4,7 @@
 
 - Analyze a trial repeatedly at planned intervals
 - Group of data added at each analysis
-- Group sequential design derives boundaries and sample size to 
+- Group sequential design derives boundaries and sample size to
   - Control Type I error
   - Ensure power
   - Stop early for futility or efficacy finding
@@ -19,10 +19,9 @@
   - $(Z_1,\ldots,Z_K)$ is multivariate normal
   - $E(Z_k) = \theta_k \sqrt{I_k}, k=1,\ldots,K$
   - $\hbox{Cov}(Z_{k_1}, Z_{k_2})=\sqrt{I_{k_1}/I_{k_2}},$ $1\le k_1\le k_2\le K$
-- $I_k$ is the Fisher information for $\theta_k, k=1,\ldots, K$. 
+- $I_k$ is the Fisher information for $\theta_k, k=1,\ldots, K$.
 - For most of this training $\theta_k=-E(\log(HR_k))$
 - Simulation can be used to examine accuracy of normal approximation
-
 
 ## Assumptions for time-to-event endpoints
 
@@ -36,17 +35,16 @@
   - Fixed design only for RMST
   - Combination tests with multiple weighted logrank tests have more complex correlation structure (@Karrison2016)
 
-## Testing bounds 
+## Testing bounds
 
 - Bounds $-\infty \le a_k \le b_k \le \infty$ for $k=1,\dots,K$
 - Null hypothesis $H_0:$ $\theta_k=0, k=1,\ldots,K$
 - Alternate hypothesis $H_1:$ $\theta_k > 0$ for some $k=1,\ldots,K$
 - Actions at analysis $k=1,\ldots,K$:
-   - Reject $H_0$ at analysis $k$ if $Z_k\ge b_k$
-   - Do not reject $H_0$ and consider stopping if $Z_k<a_k$, $k<K$
-   - Continue trial if $a_k\le Z_k\le b_k$, $k<K$
+  - Reject $H_0$ at analysis $k$ if $Z_k\ge b_k$
+  - Do not reject $H_0$ and consider stopping if $Z_k<a_k$, $k<K$
+  - Continue trial if $a_k\le Z_k\le b_k$, $k<K$
 - Bounds are generally considered advisory for stopping trial, not binding
-
 
 ## Boundary crossing probabilities
 
@@ -65,9 +63,9 @@
 
   $$-\infty\le a_k<b_k, k=1,\ldots,K-1,$$
   $$a_K\le b_K$$
-  
+
   $$1 - \beta =  \sum_{k=1}^{K} l_k = \sum_{k=1}^{K} \text{Pr}(\{Z_k < a_k\} \cap_{j=1}^{k-1} \{a_j \le Z_j \le b_j\}\mid H_1)$$
-  
+
 ## Symmetric bounds
 
 Test each treatment for superiority vs the other
@@ -140,9 +138,9 @@ x <- gsSurv(
   minfup = minfup,
   ratio = ratio
 )
-plot(x, xlab = "Events", main = "Symmetric bounds testing best of 2 treatments", col=c("red", "black")) +
-  annotate("text", x=225, y=-.5, size = 5, color = "red", label = "Futility bound crossed with low probability under H0") +
-  annotate("text", x=225, y=4.5, size = 5, label = "Efficacy bound crossed with low probability under H0")
+plot(x, xlab = "Events", main = "Symmetric bounds testing best of 2 treatments", col = c("red", "black")) +
+  annotate("text", x = 225, y = -.5, size = 5, color = "red", label = "Futility bound crossed with low probability under H0") +
+  annotate("text", x = 225, y = 4.5, size = 5, label = "Efficacy bound crossed with low probability under H0")
 ```
 
 Usually not of interest in pharmaceutical industry
@@ -155,7 +153,7 @@ Give up if experimental arm not trending in favor of control?
 # Number of analyses
 k <- 5
 # See gsDesign() help for description of boundary types
-test.type <-4
+test.type <- 4
 # 1-sided Type I error
 alpha <- 0.025
 # Type 2 error (1 - targeted power)
@@ -219,14 +217,13 @@ x <- gsSurv(
   minfup = minfup,
   ratio = ratio
 )
-plot(x, xlab = "Events", main = "Futility bounds only testing if experimental better", col=c("red", "black")) +
-  annotate("text", x=240, y=-1.5, size = 5, color = "red", label = "Futility bound crossed with low probability under H1") +
-  annotate("text", x=240, y=4.5, size = 5, label = "Efficacy bound crossed with low probability under H0")
+plot(x, xlab = "Events", main = "Futility bounds only testing if experimental better", col = c("red", "black")) +
+  annotate("text", x = 240, y = -1.5, size = 5, color = "red", label = "Futility bound crossed with low probability under H1") +
+  annotate("text", x = 240, y = 4.5, size = 5, label = "Efficacy bound crossed with low probability under H0")
 ```
 
 - Ethics of continuing trial if unlikely to show superiority?
 - Excess risk of crossing lower bound too soon?
-
 
 ## Asymmetric 2-sided testing
 
@@ -300,19 +297,19 @@ x <- gsSurv(
   minfup = minfup,
   ratio = ratio
 )
-plot(x, xlab = "Events", main = "Futility bounds testing if experimental trending worse than control", col=c("red", "black")) +
-  annotate("text", x=200, y=-.5, size = 5, color = "red", label = "Futility bound crossed with moderate probability under H0") +
-  annotate("text", x=200, y=1.6, size = 5, label = "Efficacy bound crossed with low probability under H0")
+plot(x, xlab = "Events", main = "Futility bounds testing if experimental trending worse than control", col = c("red", "black")) +
+  annotate("text", x = 200, y = -.5, size = 5, color = "red", label = "Futility bound crossed with moderate probability under H0") +
+  annotate("text", x = 200, y = 1.6, size = 5, label = "Efficacy bound crossed with low probability under H0")
 ```
 
 ## Sample size
 
 - Given boundary computation, sample size solves for enrollment rate
 - Fixing relative enrollment rates, dropout rates and trial duration enable @LachinFoulkes and our AHR methods
-- Under proportional hazards,  you can also fix max enrollment rate and solve for trial duration [@kim1990study]
-    - You can easily create scenarios here for which there is no solution 
-    - Error message *An error has occurred. Check your logs or contact the app author for clarification.*
-    - Need to adjust parameters until a solution is found or use @LachinFoulkes
+- Under proportional hazards, you can also fix max enrollment rate and solve for trial duration [@kim1990study]
+  - You can easily create scenarios here for which there is no solution
+  - Error message *An error has occurred. Check your logs or contact the app author for clarification.*
+  - Need to adjust parameters until a solution is found or use @LachinFoulkes
 
 ## Boundary types
 
@@ -328,7 +325,7 @@ plot(x, xlab = "Events", main = "Futility bounds testing if experimental trendin
       - O'Brien and Fleming boundary [@o1979multiple]
     - Slud and Wei [@SludWei, @FHO] set fixed IA probabilities
       - Hybrid of boundary family/spending approach
-      
+
 # Boundary families
 
 ## Boundary family - Haybittle-Peto boundary
@@ -342,7 +339,7 @@ plot(x, xlab = "Events", main = "Futility bounds testing if experimental trendin
 ![](../images/background_SF_Haybittle_boundary.png){ width=45% }
 </div>
 
-## Boundary family -  Haybittle-Peto (cont'd)
+## Boundary family - Haybittle-Peto (cont'd)
 
 - **Modified Haybittle-Peto procedure 1:**
 
@@ -354,7 +351,6 @@ plot(x, xlab = "Events", main = "Futility bounds testing if experimental trendin
 - **Advantages:**
   - Avoid type I error inflation
   - Does not require equally spaced analyses
-
 
 ## Boundary family - Wang-Tsiatis bounds
 
@@ -376,7 +372,6 @@ plot(x, xlab = "Events", main = "Futility bounds testing if experimental trendin
   For 2-sided testing, the Pocock procedure rejects at the $k$-th equally-spaced of $K$ looks if
   $$|Z_k| > c_P(K),$$
   where $c_P(K)$ is fixed given $K$ such that $\text{Pr}(\cup_{k=1}^{K} |Z_k| > c_P(K)) = \alpha$.
-
 
 ## Wang-Tsiatis example - Pocock boundary (cont'd)
 
@@ -417,11 +412,9 @@ plot(x, xlab = "Events", main = "Futility bounds testing if experimental trendin
 
 <div align="center">
   ![](../images/background_SF_OBF_boundary.png){ width=45% }
-
 </div>
 
-
-## Wang-Tsiatis example -  O'Brien-Fleming boundary (cont'd)
+## Wang-Tsiatis example - O'Brien-Fleming boundary (cont'd)
 
 <div style="float: left; width: 45%;">
 |total number of looks(K)| $\alpha = 0.01$ | $\alpha = 0.05$ | $\alpha = 0.1$ |
@@ -461,72 +454,82 @@ plot(x, xlab = "Events", main = "Futility bounds testing if experimental trendin
 |Pocock| a constant decision boundary for Z-score| | (1) requires the same level of evidence for early and late looks at the data, so it pays larger price for the final analysis ;<br> (2) requires equally spaced looks
 |O'Brien-Fleming| constant B-value boundaries, steep decrease in Z-boundaries |pay smaller price for the final analysis| too conservative in the early stages? |
 
-
 # Spending function boundaries
-
 
 ## Spending function
 
 ```{r,echo=FALSE}
 library(ggrepel)
-ts <- (0:100)/100
-spend <- sfHSD(alpha=.025, t = ts, param = -3)$spend
+ts <- (0:100) / 100
+spend <- sfHSD(alpha = .025, t = ts, param = -3)$spend
 timing <- c(.15, .3, .6, .8, .9, 1)
 spendb <- sfHSD(alpha = .025, t = timing, param = -3)$spend
 ds <- tibble::tibble(ts = timing, spend = spendb, txt = as.character(round(spendb, 5)))
-qplot(x=ts, y=spend, geom="line") + ylab("Cumulative alpha-spending") + xlab("Spending time") +
+qplot(x = ts, y = spend, geom = "line") + ylab("Cumulative alpha-spending") + xlab("Spending time") +
   geom_point(data = ds) + ggtitle("Spending function to specify boundary crossing probabilities") +
-  geom_label(data = ds, aes(x=ts, y= spend, label=txt)) + 
-  annotate(x=.02,y=.025,   geom="text", size=5, hjust=0, label = "- Cumulative probability of boundary crossing") +
-  annotate(x=.02,y=.0225,  geom="text", size=5, hjust=0, label = "- Timing does not have to be equally spaced") +
-  annotate(x=.02,y=.02,    geom="text", size=5, hjust=0, label = "- Timing and number of analyses can be changed during trial") + 
-  annotate(x=.06, y=.0175, geom="text", size=5, hjust=0, label= "- Requires treatment effect not revealed") +
-  annotate(x=.02, y=.015,  geom="text", size=5, hjust=0, label= "- Z-values solved by inverse multivariate normal distribution")
+  geom_label(data = ds, aes(x = ts, y = spend, label = txt)) +
+  annotate(x = .02, y = .025, geom = "text", size = 5, hjust = 0, label = "- Cumulative probability of boundary crossing") +
+  annotate(x = .02, y = .0225, geom = "text", size = 5, hjust = 0, label = "- Timing does not have to be equally spaced") +
+  annotate(x = .02, y = .02, geom = "text", size = 5, hjust = 0, label = "- Timing and number of analyses can be changed during trial") +
+  annotate(x = .06, y = .0175, geom = "text", size = 5, hjust = 0, label = "- Requires treatment effect not revealed") +
+  annotate(x = .02, y = .015, geom = "text", size = 5, hjust = 0, label = "- Z-values solved by inverse multivariate normal distribution")
 ```
 
 ## Lan-DeMets spending functions to approximate boundary families
 
 ```{r,echo=FALSE}
 library(ggrepel)
-ts <- (0:100)/100
-spendO <- sfLDOF(alpha=.025, t = ts)$spend
-spendP <- sfLDPocock(alpha=.025, t = ts)$spend
+ts <- (0:100) / 100
+spendO <- sfLDOF(alpha = .025, t = ts)$spend
+spendP <- sfLDPocock(alpha = .025, t = ts)$spend
 timing <- c(.15, .3, .6, .8, .9, 1)
 spendOBF <- sfLDOF(alpha = .025, t = timing)$spend
 spendPocock <- sfLDPocock(alpha = .025, t = timing)$spend
-ds <- rbind(tibble::tibble(ts = ts, spend = spendO, g="O'Brien-Fleming"),
-            tibble::tibble(ts = ts, spend = spendP, g="Pocock")
+ds <- rbind(
+  tibble::tibble(ts = ts, spend = spendO, g = "O'Brien-Fleming"),
+  tibble::tibble(ts = ts, spend = spendP, g = "Pocock")
 )
-dspend <- rbind(tibble::tibble(ts = timing, spend = spendOBF, txt = as.character(round(spendOBF, 5)), g="O'Brien-Fleming"),
-                tibble::tibble(ts = timing, spend = spendPocock, txt = as.character(round(spendPocock, 5)), g="Pocock")
+dspend <- rbind(
+  tibble::tibble(ts = timing, spend = spendOBF, txt = as.character(round(spendOBF, 5)), g = "O'Brien-Fleming"),
+  tibble::tibble(ts = timing, spend = spendPocock, txt = as.character(round(spendPocock, 5)), g = "Pocock")
 )
-ggplot(ds, aes(x=ts, y=spend, col=g)) +geom_line() + ylab("Cumulative alpha-spending") + xlab("Spending time") +
-  geom_point(data = dspend) + ggtitle("Lan-DeMets (1981) spending functions approximating boundary families") +
-  geom_label_repel(data = dspend, aes(x=ts, y= spend, label=txt)) +
-  guides(col = guide_legend(title="Spending function"))
+ggplot(ds, aes(x = ts, y = spend, col = g)) +
+  geom_line() +
+  ylab("Cumulative alpha-spending") +
+  xlab("Spending time") +
+  geom_point(data = dspend) +
+  ggtitle("Lan-DeMets (1981) spending functions approximating boundary families") +
+  geom_label_repel(data = dspend, aes(x = ts, y = spend, label = txt)) +
+  guides(col = guide_legend(title = "Spending function"))
 ```
 
 ## Hwang-Shih-DeCani (gamma) spending functions
 
 ```{r,echo=FALSE}
 g <- c(1, -2, -4, -8)
-ts <- (0:100)/100
+ts <- (0:100) / 100
 timing <- c(.15, .3, .6, .8, .9, 1)
 ds <- NULL
 dspend <- NULL
-for(gamma in g){
-    spend <- sfHSD(alpha=.025, t = ts, param = gamma)$spend
-    spendt <- sfHSD(alpha = .025, t = timing, param = gamma)$spend
-    ds <- rbind(ds,
-                tibble::tibble(ts = ts, spend = spend, gamma=gamma)
-    )
-    dspend <- rbind(dspend,
-                    tibble::tibble(ts = timing, spend = spendt, txt = as.character(round(spendt, 5)), gamma=gamma)
-    )
+for (gamma in g) {
+  spend <- sfHSD(alpha = .025, t = ts, param = gamma)$spend
+  spendt <- sfHSD(alpha = .025, t = timing, param = gamma)$spend
+  ds <- rbind(
+    ds,
+    tibble::tibble(ts = ts, spend = spend, gamma = gamma)
+  )
+  dspend <- rbind(
+    dspend,
+    tibble::tibble(ts = timing, spend = spendt, txt = as.character(round(spendt, 5)), gamma = gamma)
+  )
 }
-ggplot(ds, aes(x=ts, y=spend, col=factor(gamma))) + geom_line() + ylab("Cumulative alpha-spending") + xlab("Spending time") +
-  geom_point(data = dspend) + ggtitle("Hwang-Shih-DeCani spending functions") + 
-  guides(col=guide_legend(title="gamma"))
+ggplot(ds, aes(x = ts, y = spend, col = factor(gamma))) +
+  geom_line() +
+  ylab("Cumulative alpha-spending") +
+  xlab("Spending time") +
+  geom_point(data = dspend) +
+  ggtitle("Hwang-Shih-DeCani spending functions") +
+  guides(col = guide_legend(title = "gamma"))
 ```
 
 ## What is spending time?
@@ -535,7 +538,7 @@ ggplot(ds, aes(x=ts, y=spend, col=factor(gamma))) + geom_line() + ylab("Cumulati
   - Time-to-event: fraction of planned final events in analysis
   - Normal or continuous: fraction of planned final sample size in analysis
   - Usually expected by regulators
-- Calendar fraction, @LanDeMets1989 
+- Calendar fraction, @LanDeMets1989
   - Fraction of trial planned calendar duration at analysis
 - Minimum of planned and actual information fraction
   - Probably not advised yet

--- a/slides/03-s-ahr.Rmd
+++ b/slides/03-s-ahr.Rmd
@@ -26,7 +26,7 @@ knitr::include_graphics("../images/ahr_slides_KEYNOTE040.PNG")
 
 ## Delayed effect not just in oncology
 
-  Cholesterol lowering and mortality @simva4s
+Cholesterol lowering and mortality @simva4s
 
 ```{r, echo=FALSE, fig.cap="Scandinavian Simvistatin Survival Study", out.width = '80%'}
 knitr::include_graphics("../images/ahr_slides_SSSS.jpeg")
@@ -84,7 +84,6 @@ knitr::include_graphics("../images/ahr_slides_KEYNOTE061OS.PNG")
 
 </div>
 
-
 ## Summary of issues
 
 - What is the impact of (potentially) delayed treatment effect on trial design and analysis?
@@ -99,7 +98,7 @@ knitr::include_graphics("../images/ahr_slides_KEYNOTE061OS.PNG")
 
 `simtrial`, `gsDesign2` and `gsdmvn` are under development and hosted on GitHub/Merck.
 
-Below is the Github repo link to the source code
+Below is the GitHub repo link to the source code
 
 - `simtrial`: <https://github.com/Merck/simtrial>
 - `gsDesign2`: <https://github.com/Merck/gsDesign2>
@@ -124,24 +123,24 @@ How to report issues?
 
 - Generating simulated datasets
   - `simfix()`: Simulation of fixed sample size design for time-to-event endpoint
-  - `simfix2simPWSurv()`: Conversion of enrollment and failure rates from simfix() to simPWSurv() format
+  - `simfix2simPWSurv()`: Conversion of enrollment and failure rates from `simfix()` to `simPWSurv()` format
   - `simPWSurv()`: Simulate a stratified time-to-event outcome randomized trial
 
 - Cutting data for analysis
-  - `cutData()`: Cut a Dataset for Analysis at a Specified Date
-  - `cutDataAtCount()`: Cut a Dataset for Analysis at a Specified Event Count
-  - `getCutDateForCount()`: Get Date at Which an Event Count is Reached
+  - `cutData()`: Cut a dataset for analysis at a specified date
+  - `cutDataAtCount()`: Cut a dataset for analysis at a specified event count
+  - `getCutDateForCount()`: Get date at which an event count is reached
 - Analysis functions
-  - `tenFH()`: Fleming-Harrington Weighted Logrank Tests
-  - `tenFHcorr()`: Fleming-Harrington Weighted Logrank Tests plus Correlations
-  - `tensurv()`: Process Survival Data into Counting Process Format
+  - `tenFH()`: Fleming-Harrington weighted logrank tests
+  - `tenFHcorr()`: Fleming-Harrington weighted logrank tests plus correlations
+  - `tensurv()`: Process survival data into counting process format
   - `pMaxCombo()`: MaxCombo p-value
   - `pwexpfit()`: Piecewise exponential survival estimation
-  - `wMB()`: Magirr and Burman Modestly Weighted Logrank Tests
+  - `wMB()`: Magirr and Burman modestly weighted logrank tests
 - Lower level functions
   - `fixedBlockRand()`: Permuted fixed block randomization
-  - `rpwenroll()`: Generate Piecewise Exponential Enrollment
-  - `rpwexp()`: The Piecewise Exponential Distribution
+  - `rpwenroll()`: Generate piecewise exponential enrollment
+  - `rpwexp()`: The piecewise exponential distribution
 
 ## simtrial: reverse engineered datasets
 
@@ -164,7 +163,7 @@ From NPH Working Group
 - `s2pwe()`: Approximate survival distribution with piecewise exponential distribution
 - `tEvents()`: Predict time at which a targeted event count is achieved
 
-We will focus on `AHR()`, `ppwe()` and `s2pwe()` in this training.
+We will focus on `AHR()`, `ppwe()`, and `s2pwe()` in this training.
 
 ## gsdmvn
 
@@ -174,10 +173,10 @@ Power and design functions extending the @JTBook computational model to non-cons
   - `gs_power_ahr()`: Power computation
   - `gs_design_ahr()`: Design computations
 - Bound support
-  - `gsb()`: direct input of bounds
+  - `gs_b()`: direct input of bounds
   - `gs_spending_bound()`: spending function bounds
 - Other tests
-  - Design and power with weighted logrank and MaxCombo will be discussed in next section. 
+  - Design and power with weighted logrank and MaxCombo will be discussed in next section.
 
 # The piecewise model
 
@@ -190,7 +189,7 @@ Power and design functions extending the @JTBook computational model to non-cons
 - Combined tools for designing and evaluating designs
   - Asymptotic approach using average hazard ratio (AHR)
   - Simulation tools to confirm asymptotic approximations
-  - No requirement for for proportional hazards
+  - No requirement for proportional hazards
   - Stick with logrank for this section
 
 ## Piecewise constant enrollment
@@ -250,7 +249,7 @@ ggplot(enroll, aes(x = Month, y = Enrollment)) +
 - **simtrial** package assumes the latter
   - Also used in AHR approach here
 - **npsurvSS** package assumes the former
-   - Used for weighted logrank and combination tests in next section 
+  - Used for weighted logrank and combination tests in next section
 
 ## Failure rates
 
@@ -264,7 +263,6 @@ $$
     \lambda=&\log(2)/m \\
   \end{align}
 $$
-
 
 Specify failure rates and dropout rates in same table
 
@@ -427,7 +425,6 @@ ggplot(xx, aes(x = Time, y = Survival, col = Value, fill = Value)) +
 
 - Geometric mean hazard ratio (@Mukhopadhyay2020)
 - Exponentiate: average $\log(\hbox{HR})$ weighted by expected events per interval
-
 
 ```{r, warning=FALSE, message=FALSE, echo=FALSE}
 library(dplyr)
@@ -645,7 +642,7 @@ ahr <- gsDesign2::AHR(
   - Code here is detailed, but (hopefully) not complicated
   - AHR changes if event-based
   - Number of events variable if time-based
-  
+
 ## Simulation code
 
 ```{r, eval=FALSE}
@@ -786,7 +783,6 @@ $$\hbox{Corr}(Z_j,Z_k)=\sqrt{t_j/t_k}$$
     - Compute expected Cox coefficient $\beta$ ($=\log(AHR)$) as before and set $\theta(t_k)=\beta$
 - We now have *canonical form* for the piecewise model
 
-
 # Group sequential design with spending bounds
 
 ## Recalling assumptions
@@ -852,7 +848,6 @@ timing
 
 ## One-sided design with proportional hazards (gsDesign)
 
-
 ```{r}
 PH1sided <- gsDesign::gsSurv( # Derive Group Sequential Design
   k = 4, # Number of analyses (interim + final)
@@ -873,11 +868,10 @@ PH1sided <- gsDesign::gsSurv( # Derive Group Sequential Design
 )
 ```
 
-
 ## One-sided design with gsSurv() {.smaller}
 
 ```{r, echo=FALSE}
-gsBoundSummary(PH1sided) %>%  gt() 
+gsBoundSummary(PH1sided) %>%  gt()
 ```
 
 ## One-sided design with gsSurv()
@@ -909,9 +903,7 @@ NPH1sided <- gs_design_ahr(
 )
 ```
 
-
 ## One-sided design with gs_design_ahr()
-
 
 ```{r, echo=FALSE}
 NPH1sided$bounds %>%
@@ -927,7 +919,6 @@ NPH1sided$bounds %>%
 - Interim boundary crossing probability much lower than with PH bounds
   - IA 2 crossing probability 50% under PH
 - Sample size larger than for PH (N=444, 297 events)
-
 
 # Symmetric bounds
 
@@ -946,7 +937,6 @@ $$
 $$
 
 ## Symmetric design with gsSurv() {.smaller}
-
 
 ```{r, echo=FALSE}
 # Derive Group Sequential Design
@@ -969,7 +959,6 @@ PHsymmetric <- gsDesign::gsSurv(
   ratio = 1 # Experimental:Control randomization ratio
 )
 ```
-
 
 ```{r, echo=FALSE}
 gsBoundSummary(PHsymmetric) %>%
@@ -1068,7 +1057,6 @@ PHasymmetric <- gsDesign::gsSurv(
   minfup = max(analysisTimes) - sum(enrollRates$duration),
   ratio = 1) # Experimental:Control randomization ratio
 ```
-
 
 ```{r, echo=FALSE}
 gsBoundSummary(PHasymmetric) %>% gt()

--- a/slides/03-s-proportional-hazards.Rmd
+++ b/slides/03-s-proportional-hazards.Rmd
@@ -1,8 +1,6 @@
-# (PART) General methods and proportional hazards {-}
-
+# General methods and proportional hazards
 
 # Proportional hazards approach
-
 
 ## @LachinFoulkes method {#lachin-foulkes}
 
@@ -15,9 +13,9 @@
 
 ## Shiny app for proportional hazards
 
-- Shiny app available at: 
-  + <https://rinpharma.shinyapps.io/gsdesign/> (preferred) 
-  + <https://gsdesign.shinyapps.io/devel/> (not preferred)
+- Shiny app available at:
+  - <https://rinpharma.shinyapps.io/gsdesign/> (preferred)
+  - <https://gsdesign.shinyapps.io/devel/> (not preferred)
 - Allows broad specification of designs
 - Much simpler than writing code
 - It will write code and reports for you
@@ -27,12 +25,12 @@
 ## Metastatic oncology example {#mediansurvival}
 
 - KEYNOTE 189 trial (@KEYNOTE189)
-   - Endpoints: progression free survival (PFS) and overall survival (OS) in patients
-   - Indication: previously untreated metastatic non-small cell lung cancer (NSCLC)
-   - Treatments: chemotherapy +/- pembrolizumab
-   - Randomized 2:1 to an add-on of pembrolizumab or placebo
-   - Type I error (1-sided): 0.025 familywise error rate (FWER) split between PFS ($\alpha=0.0095$) and OS ($\alpha=0.0155$)
-   - Graphical method $\alpha$-control for group sequential design of @MaurerBretz2013 used
+  - Endpoints: progression free survival (PFS) and overall survival (OS) in patients
+  - Indication: previously untreated metastatic non-small cell lung cancer (NSCLC)
+  - Treatments: chemotherapy +/- pembrolizumab
+  - Randomized 2:1 to an add-on of pembrolizumab or placebo
+  - Type I error (1-sided): 0.025 familywise error rate (FWER) split between PFS ($\alpha=0.0095$) and OS ($\alpha=0.0155$)
+  - Graphical method $\alpha$-control for group sequential design of @MaurerBretz2013 used
 
 Key aspects of the design as documented in the protocol accompanying @KEYNOTE189.
 
@@ -49,11 +47,10 @@ Key aspects of the design as documented in the protocol accompanying @KEYNOTE189
   - Observed deaths of 240, 332 and 416 at the 3 planned analyses
   - A one-sided bound using the @LanDeMets spending approximating an O'Brien-Fleming bound.
 
-
 ## Cardiovascular outcomes reduction
 
 - AFCAPS/TEXCAPS trial: use of lovastatin to reduce cardiovascular outcomes
-- Design described in @AFCAPSdesign 
+- Design described in @AFCAPSdesign
 - Results reported in @AFCAPSresults
 - Reproduction here not exact mainly due to choice of @LachinFoulkes
   - Little difference between methods
@@ -69,7 +66,6 @@ Key aspects of the design as documented in the protocol accompanying @KEYNOTE189
   - Enrollment duration of 1/2 year with constant enrollment.
   - An exponential failure rate of 0.01131 per year which is nearly identical to the annual dropout rate of `r round(1 - exp(-.01131),5)`.
   - An exponential dropout rate of 0.004 per year which is nearly identical to the annual dropout rate of `r round(1 - exp(-.004),5)`.
-
 
 ## Cardiovascular outcomes non-inferiority: EXAMINE trial
 
@@ -108,7 +104,7 @@ Note that:
 - $1-\exp(-\lambda t)$ is the CDF for an exponential distribution
   - can be replaced by arbitrary continuous CDF.
 - As $t\rightarrow \infty$, $S(t)\rightarrow\exp(-\theta)$ (cure rate).
-- Model useful when historical data suggests plateau in survival. 
+- Model useful when historical data suggests plateau in survival.
 - PH model: experimental survival $S_E(t)=S_C(t)^{HR}$.
 
 ## Survival model assumptions
@@ -118,6 +114,7 @@ library(ggplot2)
 library(dplyr)
 library(gsDesign)
 library(gt)
+
 # Assumed long-term survival rate
 cureRate <- 0.7
 # Survival rate at specific time
@@ -147,18 +144,17 @@ ggplot(cure_model, aes(x = Month, y = Survival, col = Treatment)) +
   annotate("text", x = 36, y = .66, label = "0.75 control survival at 18 months") +
   annotate("text", x = 36, y = .9, label = "Hazard ratio (experimental/contrl) = 0.72") +
   scale_x_continuous(breaks = seq(0, maxTime, 6)) +
-  scale_y_continuous(breaks = seq(.6, 1, .1), limits = c(.6, 1))+
+  scale_y_continuous(breaks = seq(.6, 1, .1), limits = c(.6, 1)) +
   ggtitle("Underlying survival assumptions for cure model design example")
 cure_model <- cure_model %>%
   mutate(
     H = -log(Survival),
     duration = Month - lag(Month, default = 0),
     h = (H - lag(H, default = 0) / duration)
-  ) 
+  )
 ```
 
 More details in book.
-
 
 ## Cure model: Expected event accumulation over time
 
@@ -175,7 +171,6 @@ enrollDurations <- c(2, 2, 2, 12)
 ```
 
 ## Expected event accrual over time
-
 
 ```{r, out.width="100%", echo=FALSE}
 # Calendar times
@@ -208,27 +203,28 @@ for (i in seq_along(ti[-1])) {
   n[i + 1] <- nEventsIA(tIA = ti[i + 1], x = xx)
 }
 # Now do a line plot of % of final events and % of final time by month
-ev <- rbind(tibble(Month = ti, ev = n / max(n) * 100, s = "Event fraction"),
-            tibble(Month = ti, ev = ti/max(ti) * 100, s = "Calendar fraction")
+ev <- rbind(
+  tibble(Month = ti, ev = n / max(n) * 100, s = "Event fraction"),
+  tibble(Month = ti, ev = ti / max(ti) * 100, s = "Calendar fraction")
 )
 p <- ggplot(ev, aes(x = Month, y = ev, col = factor(s))) +
   geom_line() +
   ylab("Spending time (%)") +
   xlab("Study Time") +
   scale_x_continuous(breaks = seq(0, maxTime, 12)) +
-  scale_y_continuous(breaks = seq(0, 100, 20)) + 
-  guides(col=guide_legend(title="Spending type"))
+  scale_y_continuous(breaks = seq(0, 100, 20)) +
+  guides(col = guide_legend(title = "Spending type"))
 # Add text overlay at targeted analysis times
 subti <- c(12, 18, 24, 36, 48, 60)
 subpct <- n[subti + 1] / n[maxTime + 1] * 100
 subtipct <- subti / max(subti) * 100
 txt <- rbind(
-  tibble(Month = subti, ev = subpct,   s = "Event fraction", txt = paste(as.character(round(subpct, 1)), "%", sep = "")),
+  tibble(Month = subti, ev = subpct, s = "Event fraction", txt = paste(as.character(round(subpct, 1)), "%", sep = "")),
   tibble(Month = subti, ev = subtipct, s = "Calendar fraction", txt = paste(as.character(round(subtipct, 1)), "%", sep = ""))
 )
-p + geom_label(data = txt, aes(x = Month, y = ev, col = factor(s), label = txt))+ 
+p + geom_label(data = txt, aes(x = Month, y = ev, col = factor(s), label = txt)) +
   ggtitle("Calendar vs. event fraction spending for cure model example") +
-  annotate("text", x=8, y=2, size = 4, color = "black", label = "- Calendar spending preserves more alpha to final analysis", hjust=0) 
+  annotate("text", x = 8, y = 2, size = 4, color = "black", label = "- Calendar spending preserves more alpha to final analysis", hjust = 0)
 ```
 
 ## Potential advantages/disadvantages of calendar spending
@@ -236,7 +232,7 @@ p + geom_label(data = txt, aes(x = Month, y = ev, col = factor(s), label = txt))
 - Quite possible that event rate design assumptions incorrect
 - Good to ensure duration of follow-up is adequate evaluate tail behavior/plateau in survival
 - Ensures adequate follow-up to estimate relevant parts of survival curve
-- Limits trial to relevant clinical and practical 
+- Limits trial to relevant clinical and practical
 - May be underpowered if events accrue slowly
 - Probably less useful for high-risk endpoints (e.g., metastatic cancer)
 - Regulatory resistance?
@@ -246,6 +242,5 @@ p + geom_label(data = txt, aes(x = Month, y = ev, col = factor(s), label = txt))
 See the following link for the Moderna COVID-19 design replication: <https://medium.com/@yipeng_39244/reverse-engineering-the-statistical-analyses-in-the-moderna-protocol-2c9fd7544326>
 
 Can you reproduce this using the Shiny interface?
-
 
 # Break (15 minutes)

--- a/slides/04-s-other-tests.Rmd
+++ b/slides/04-s-other-tests.Rmd
@@ -26,13 +26,13 @@ For simplicity, we made a few key assumptions.
 - Balanced design (1:1 randomization ratio).
 - 1-sided test.
 - Local alternative: variance under null and alternative are approximately equal.
-- Accrual distribution: Piecewise uniform. 
+- Accrual distribution: Piecewise uniform.
 - Survival distribution: piecewise exponential.
 - Loss to follow-up: exponential.
 - No stratification.
 - No cure fraction.
 
-The fixed design part largely follow the concept described in @yung2019sample.
+The fixed design part largely follows the concept described in @yung2019sample.
 
 ## Notation
 

--- a/slides/05-s-conclusions.Rmd
+++ b/slides/05-s-conclusions.Rmd
@@ -9,22 +9,22 @@
   - Consider a treatment effect delay that is *intermediate*
   - Understand likely enrollment pattern and dropout rate
   - Plot AHR, underying survival differences and expected accrual of patients and events
-  
-## Where to start for NPH? 
+
+## Where to start for NPH?
 
 - Follow-up (trial duration)
   - Get to *good* part of AHR could (it will plateau under above assumptions)
   - Ensure follow-up long enough to ensure *tail* characterization
   - Require both minimum follow-up and sufficient events for final analysis
-  
+
 ## Simplest design approach
 
 - Start with AHR from above evaluation
 - Design under proportional hazards assuming constant AHR
 - Ensure early futility bounds are not too aggressive
-   - No futility (risk that data monitoring committee will overrule)
-   - $\beta$-spending: be conservative for early bounds
-   - Asymmetric 2-sided test; e.g., Pocock-like bound with *moderate* total boundary crossing probability
+  - No futility (risk that data monitoring committee will overrule)
+  - $\beta$-spending: be conservative for early bounds
+  - Asymmetric 2-sided test; e.g., Pocock-like bound with *moderate* total boundary crossing probability
 - Efficacy bounds: O'Brien-Fleming always acceptable to regulators
 - This is easy to do with gsDesign Shiny app!
 
@@ -40,7 +40,6 @@
   - Haybittle-Peto bounds
   - Futility or efficacy bounds can be eliminated from selected analyses
 
-
 ## Less conventional tests
 
 - RMST has been heavily promoted
@@ -51,8 +50,7 @@
   - MaxCombo test at final analysis only
 - There can be substantial power gains
 
-
 ## Thank you!
 
 - Feedback and questions are welcome!
-- May wish to submit by issues at github repositories, but e-mail also OK.
+- May wish to submit by issues at GitHub repositories, but e-mail also OK.

--- a/wlr-boundary.Rmd
+++ b/wlr-boundary.Rmd
@@ -19,7 +19,7 @@ The spending function has been implemented in `gsDesign`.
 - `gsDesign::sfLDOF()` (O'Brien-Fleming bound approximation) or other functions starting with `sf` in `gsDesign`
 - The boundary family approach. @pocock1977group, @o1979multiple, @wang1987approximately
 
-There are other way to derive boundary but will not be covered:
+There are other ways to derive boundary but will not be covered:
 
 - Conditional power. @lachin2005review
 

--- a/wlr.Rmd
+++ b/wlr.Rmd
@@ -11,18 +11,18 @@ In this chapter, we start to discuss group sequential design for weighted logran
 
 ## Assumptions
 
-For a group sequential design, we assume there are there are total $K$ analyses in a trial.
+For a group sequential design, we assume there are total $K$ analyses in a trial.
 The **calendar** time of the analyses are $t_k, k =1,\dots, K$.
 
 We define the test statistic at analysis $k=1,2,\dots,K$ as
 
 $$Z_k =  \frac{\widehat{\Delta}_k}{\sigma(\widehat{\Delta}_k)}$$
-where $\widehat{\Delta}_k$ is a statistics to characterize group difference and 
+where $\widehat{\Delta}_k$ is a statistics to characterize group difference and
 $\sigma(\widehat{\Delta}_k)$ is the standard deviation of $\widehat{\Delta}_k$.
 
 ### Asymptotic normality
 
-In group sequential design, we considered the test statistics are asymptotic normal.
+In group sequential design, we consider the test statistics are asymptotically normal.
 
 - Under the null hypothesis
 
@@ -108,7 +108,7 @@ x$upper$bound
 
 Given the lower and upper bound of a group sequential design, we can calculate the overall power of the design.
 
-- Power: under an (local) alternative hypothesis, the probability to reject the null hypothesis.
+- Power: under a (local) alternative hypothesis, the probability to reject the null hypothesis.
 
 $$1 - \beta =\sum_{k=1}^{K} u_k = \sum_{k=1}^{K} \text{Pr}(\{Z_k \ge b_k\} \cap_{j=1}^{k-1} \{a_j \le Z_j \le b_j\} \mid H_1)$$
 
@@ -125,14 +125,13 @@ $$\sum_{k=1}^{K} l_k = \sum_{k=1}^{K} \text{Pr}(\{Z_k < a_k\} \cap_{j=1}^{k-1} \
 
 ## Weighted logrank test
 
-Similar to the fixed design, we can define the test statistics for weighted logrank test using counting process formula as 
+Similar to the fixed design, we can define the test statistics for weighted logrank test using counting process formula as
 
 $$ Z_k=\sqrt{\frac{n_{0}+n_{1}}{n_{0}n_{1}}}\int_{0}^{t_k}w(t)\frac{\overline{Y}_{0}(t)\overline{Y}_{1}(t)}{\overline{Y}_{0}(t)+\overline{Y}_{0}(t)}\left\{ \frac{d\overline{N}_{1}(t)}{\overline{Y}_{1}(t)}-\frac{d\overline{N}_{0}(t)}{\overline{Y}_{0}(t)}\right\} $$
 
-Here $n_i$ are number of subjects in group $i$.
-$\overline{Y}_{i}(t)$ are number of subjects in group $i$ at risk at time $t$.
-$\overline{N}_{i}(t)$ are number of events in group $i$ up to and including time $t$.
-
+Here $n_i$ are the number of subjects in group $i$.
+$\overline{Y}_{i}(t)$ are the number of subjects in group $i$ at risk at time $t$.
+$\overline{N}_{i}(t)$ are the number of events in group $i$ up to and including time $t$.
 
 Note, the only difference is that the test statistics fixed analysis up to $t_k$ at $k$th interim analysis
 
@@ -195,8 +194,8 @@ gsdmvn::gs_design_ahr(
   lpar = x$lower$bound,
   analysisTimes = analysisTimes
 )$bounds %>%
-  mutate_if(is.numeric, round, digits = 2) %>% 
-  select(Analysis, Bound, Time, N, Events, AHR, Probability) %>% 
+  mutate_if(is.numeric, round, digits = 2) %>%
+  select(Analysis, Bound, Time, N, Events, AHR, Probability) %>%
   tidyr::pivot_wider(names_from = Bound, values_from = Probability)
 ```
 
@@ -207,7 +206,7 @@ load("simulation/simu_gsd_wlr.Rdata")
 res %>%
   subset(n == 386 & rho == 0 & gamma == 0) %>%
   select(-scenario, -rho, -gamma) %>%
-  mutate_if(is.numeric, round, digits = 2) 
+  mutate_if(is.numeric, round, digits = 2)
 ```
 
 - $FH(0,0)$
@@ -223,8 +222,8 @@ gsdmvn::gs_design_wlr(
   lpar = x$lower$bound,
   analysisTimes = c(12, 24, 36)
 )$bounds %>%
-  mutate_if(is.numeric, round, digits = 2) %>% 
-  select(Analysis, Bound, Time, N, Events, AHR, Probability) %>% 
+  mutate_if(is.numeric, round, digits = 2) %>%
+  select(Analysis, Bound, Time, N, Events, AHR, Probability) %>%
   tidyr::pivot_wider(names_from = Bound, values_from = Probability)
 ```
 
@@ -238,7 +237,7 @@ res %>%
   mutate_if(is.numeric, round, digits = 2)
 ```
 
-## Sample size under modesetly WLR cut at 4 months
+## Sample size under modestly WLR cut at 4 months
 
 - Modestly WLR: $S^{-1}(t\land\tau_m)$ @magirr2019modestly
 
@@ -269,8 +268,8 @@ gsdmvn::gs_design_wlr(
   lpar = x$lower$bound,
   analysisTimes = analysisTimes
 )$bounds %>%
-  mutate_if(is.numeric, round, digits = 2) %>% 
-  select(Analysis, Bound, Time, N, Events, AHR, Probability) %>% 
+  mutate_if(is.numeric, round, digits = 2) %>%
+  select(Analysis, Bound, Time, N, Events, AHR, Probability) %>%
   tidyr::pivot_wider(names_from = Bound, values_from = Probability)
 ```
 
@@ -297,8 +296,8 @@ gsdmvn::gs_design_wlr(
   lpar = x$lower$bound,
   analysisTimes = analysisTimes
 )$bounds %>%
-  mutate_if(is.numeric, round, digits = 2) %>% 
-  select(Analysis, Bound, Time, N, Events, AHR, Probability) %>% 
+  mutate_if(is.numeric, round, digits = 2) %>%
+  select(Analysis, Bound, Time, N, Events, AHR, Probability) %>%
   tidyr::pivot_wider(names_from = Bound, values_from = Probability)
 ```
 
@@ -325,8 +324,8 @@ gsdmvn::gs_design_wlr(
   lpar = x$lower$bound,
   analysisTimes = analysisTimes
 )$bounds %>%
-  mutate_if(is.numeric, round, digits = 2) %>% 
-  select(Analysis, Bound, Time, N, Events, AHR, Probability) %>% 
+  mutate_if(is.numeric, round, digits = 2) %>%
+  select(Analysis, Bound, Time, N, Events, AHR, Probability) %>%
   tidyr::pivot_wider(names_from = Bound, values_from = Probability)
 ```
 
@@ -340,7 +339,7 @@ res %>%
   mutate_if(is.numeric, round, digits = 2)
 ```
 
-## Average hazard ratio comparision
+## Average hazard ratio comparison
 
 The average hazard ratio depends on the weight used in the WLR.
 We illustrate the difference in the figure below.
@@ -351,9 +350,9 @@ knitr::include_graphics("images/g_ahr.png")
 
 Note that average hazard ratio is weighted by corresponding weighted logrank weights.
 
-## Standardized effect size comparision
+## Standardized effect size comparison
 
-Standardized effect size of $FH(0, 0.5)$ is larger than other weight function at 36 Month.
+Standardized effect size of $FH(0, 0.5)$ is larger than other weight function at month 36.
 The reason $FH(0.5, 0.5)$ provides slightly smaller sample size compared with $FH(0, 1)$ and $FH(0, 0.5)$
 is mainly due to smaller weight when variance becomes larger than $FH(0, 1)$ with later events.
 
@@ -361,9 +360,9 @@ is mainly due to smaller weight when variance becomes larger than $FH(0, 1)$ wit
 knitr::include_graphics("images/g_theta.png")
 ```
 
-## Information fraction comparision
+## Information fraction comparison
 
-logrank test information fraction curve is close to linear function of time (the boundary calculation approach we used).
+The logrank test information fraction curve is close to linear function of time (the boundary calculation approach we used).
 Other WLR test information fraction curves are convex functions.
 Information Fraction under null hypothesis is smaller than information fraction under alternative at the same time.
 
@@ -396,7 +395,8 @@ arm0 <- gs_arm[["arm0"]]
 arm1 <- gs_arm[["arm1"]]
 ```
 
-The calculation of power is essentially the multiple integration of multivariate normal distribution, and we implement it into a function `gs_power()` where `mvtnorm::pmvnorm()` is used to take care of the multiple integration. 
+The calculation of power is essentially the multiple integration of multivariate normal distribution, and we implement it into a function `gs_power()` where `mvtnorm::pmvnorm()` is used to take care of the multiple integration.
+
 ```{r}
 #' Power and futility of group sequential design
 #'
@@ -430,7 +430,7 @@ To utilize `gs_power()`, four important blocks are required.
 1. The numerical vector of futility bound for multiple integration.
 1. The numerical vector of efficacy bound for multiple integration.
 
-First, we calculate 
+First, we calculate
 $$
   \Delta_k
   =
@@ -438,9 +438,10 @@ $$
 $$
 where $p_0 = n_0/(n_0 + n_1), p_1 = n_1/(n_0 + n_1)$ are the randomization ratio of the control and treatment arm, respectively.
 $\pi_0(t) = E(N_0(t)), \pi_1(t) = E(N_1(t))$ are the expected number of failures of the control and treatment arm, respectively.
-$\pi(t) = p_0 \pi_0(t) + p_1 \pi_1(t)$ is the probability of events. 
+$\pi(t) = p_0 \pi_0(t) + p_1 \pi_1(t)$ is the probability of events.
 $\lambda_0(t), \lambda_1(t)$ are hazard functions.
 The detailed calculation of $\Delta_k$ is implemented in `gsdmvn:::gs_delta_wlr()`:
+
 ```{r}
 delta <- abs(sapply(analysisTimes, function(x) {
   gsdmvn:::gs_delta_wlr(arm0, arm1, tmax = x, weight = weight)
@@ -448,10 +449,11 @@ delta <- abs(sapply(analysisTimes, function(x) {
 delta
 ```
 
-Second, we calculate 
+Second, we calculate
 $$\sigma_k^{2}=\int_{0}^{t_k}w(s)^{2}\frac{p_{0}\pi_{0}(s)p_{1}\pi_{1}(s)}{\pi(s)^{2}}dv(s), $$
 where $v(t)= p_0 E(Y_0(t)) + p_1 E(Y_1(t))$ is the probability of people at risk.
 The detailed calculation of $\sigma_k^{2}$ is implemented in `gsdmvn:::gs_sigma2_wlr()`:
+
 ```{r}
 sigma2 <- abs(sapply(analysisTimes, function(x) {
   gsdmvn:::gs_sigma2_wlr(arm0, arm1, tmax = x, weight = weight)
@@ -460,14 +462,16 @@ sigma2
 ```
 
 Third, we calculate the sample size ratio at each interim analysis can be calculated by
+
 ```{r}
 # Group sequential sample size ratio over time
 gs_n_ratio <- (npsurvSS::paccr(analysisTimes, arm0) +
-                 npsurvSS::paccr(analysisTimes, arm1)) / 2
+  npsurvSS::paccr(analysisTimes, arm1)) / 2
 gs_n_ratio
 ```
 
-After getting $\Delta_k$, $\sigma_k^{2}$ and the sample size ratio, one can calculate the expectation mean of Z statistics as 
+After getting $\Delta_k$, $\sigma_k^{2}$ and the sample size ratio, one can calculate the expectation mean of Z statistics as
+
 ```{r}
 n <- 500 # Assume a sample size to get power
 delta / sqrt(sigma2) * sqrt(gs_n_ratio * n)
@@ -480,28 +484,30 @@ corr <- outer(sqrt(sigma2), sqrt(sigma2), function(x, y) pmin(x, y) / pmax(x, y)
 corr
 ```
 
-Finally, for numerical vector of futility and bound, they are simply 
+Finally, for numerical vector of futility and bound, they are simply
+
 ```{r}
 x$lower$bound
 x$upper$bound
 ```
+
 ### Power and sample size calculation
 
-- **Power** 
+- **Power**
 
-With all blocks prepared, one can calculate the power 
+With all blocks prepared, one can calculate the power
 $$
-  1 -\beta 
+  1 -\beta
   =
   \sum_{k=1}^{K} u_k = \sum_{k=1}^{K} \text{Pr}(\{Z_k \ge b_k\} \cap_{j=1}^{k-1} \{a_j \le Z_j \le b_j\})
 $$
 by
-```{r}
 
+```{r}
 cumsum(gs_power(
   delta / sqrt(sigma2) * sqrt(gs_n_ratio * n),
-  corr, 
-  x$lower$bound, 
+  corr,
+  x$lower$bound,
   x$upper$bound
 ))
 ```
@@ -512,10 +518,11 @@ One can also calculate the type I error by
 
 ```{r}
 cumsum(gs_power(
-  rep(0, length(delta)), 
-  corr, 
-  rep(-Inf, length(delta)), 
-  x$upper$bound))
+  rep(0, length(delta)),
+  corr,
+  rep(-Inf, length(delta)),
+  x$upper$bound
+))
 ```
 
 - **Futility probability**
@@ -524,6 +531,7 @@ Similarly, we can calculate the futility probability
 
 $$\sum_{k=1}^{K} l_k = \sum_{k=1}^{K} \text{Pr}(\{Z_k < a_k\} \cap_{j=1}^{k-1} \{a_j \le Z_j \le b_j\})$$
 by
+
 ```{r}
 #' @rdname power_futility
 gs_futility <- function(z, corr, futility_bound, efficacy_bound) {
@@ -552,7 +560,7 @@ cumsum(gs_futility(
 
 - **Sample size**
 
-In additional to power and futility probability, one can also calculate the sample size by 
+In additional to power and futility probability, one can also calculate the sample size by
 
 ```{r}
 efficacy_bound <- x$upper$bound
@@ -577,7 +585,8 @@ n_subject * gs_n_ratio
 
 - **Number of events**
 
-With the sample size available, one can calculate the number of events by 
+With the sample size available, one can calculate the number of events by
+
 ```{r}
 n0 <- n1 <- n_subject / 2
 gsdmvn:::prob_event.arm(arm0, tmax = analysisTimes) * n0 +
@@ -586,7 +595,7 @@ gsdmvn:::prob_event.arm(arm0, tmax = analysisTimes) * n0 +
 
 - **Average hazard ratio**
 
-The function below implement the connection between $\Delta$ and average hazard ratio using 
+The function below implement the connection between $\Delta$ and average hazard ratio using
 Taylor series expansion.
 
 ```{r}


### PR DESCRIPTION
This PR fixes a few apparent typos, corrects a few Markdown style and formatting issues, and removes trailing whitespaces.