### PR TITLE
Fix build and bibliography

### DIFF
--- a/.github/workflows/bookdown.yaml
+++ b/.github/workflows/bookdown.yaml
@@ -12,6 +12,9 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
+      - name: Install libcurl for R package curl
+        run: sudo apt-get update && sudo apt-get libcurl4-openssl-dev
+
       - uses: actions/checkout@v2
 
       - uses: r-lib/actions/setup-pandoc@v1

--- a/.github/workflows/bookdown.yaml
+++ b/.github/workflows/bookdown.yaml
@@ -13,7 +13,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Install libcurl for R package curl
-        run: sudo apt-get update && sudo apt-get libcurl4-openssl-dev
+        run: sudo apt-get update && sudo apt-get install libcurl4-openssl-dev
 
       - uses: actions/checkout@v2
 

--- a/Deming2021.bib
+++ b/Deming2021.bib
@@ -1,48 +1,22 @@
-@article{Hasegawa2014,
-  title     = {Sample size determination for the weighted log-rank test with the Fleming--Harrington class of weights in cancer vaccine studies},
-  author    = {Hasegawa, Takahiro},
-  journal   = {Pharmaceutical Statistics},
-  volume    = {13},
-  number    = {2},
-  pages     = {128--135},
-  year      = {2014},
-  publisher = {Wiley Online Library}
-}
-@article{KimTsiatis,
-  author  = {Kyungmann Kim  and Anastasios A. Tsiatis},
-  title   = {Study duration for clinical trials with survival response and early stopping rule.},
-  journal = {Biometrics},
-  volume  = {46},
-  year    = {1990},
-  pages   = {81-92}
-}
-@article{gordon1983discrete,
-  title     = {Discrete sequential boundaries for clinical trials},
-  author    = {Gordon Lan, KK and DeMets, David L},
-  journal   = {Biometrika},
-  volume    = {70},
+@article{AFCAPSdesign,
+  title     = {Design \& rationale of the Air Force/Texas coronary atherosclerosis prevention study (AFCAPS/TexCAPS)},
+  author    = {Downs, John R and Beere, Polly A and Whitney, Edwin and Clearfield, Michael and Weis, Stephen and Rochen, Jeffrey and Stein, Evan A and Shapiro, Deborah R and Langendorfer, Alexandra and Gotto Jr, Antonio M},
+  journal   = {The American Journal of Cardiology},
+  volume    = {80},
   number    = {3},
-  pages     = {659--663},
-  year      = {1983},
-  publisher = {Oxford University Press}
+  pages     = {287--293},
+  year      = {1997},
+  publisher = {Elsevier}
 }
-@article{karrison2016versatile,
-  title     = {Versatile tests for comparing survival curves based on weighted log-rank statistics},
-  author    = {Karrison, Theodore G},
-  journal   = {The Stata Journal},
-  volume    = {16},
-  number    = {3},
-  pages     = {678--690},
-  year      = {2016},
-  publisher = {SAGE Publications Sage CA: Los Angeles, CA}
-}
-@article{lachin1986evaluation,
-  title     = {Evaluation of sample size and power for analyses of survival with allowance for nonuniform patient entry, losses to follow-up, noncompliance, and stratification},
-  author    = {Lachin, John M and Foulkes, Mary A},
-  journal   = {Biometrics},
-  pages     = {507--519},
-  year      = {1986},
-  publisher = {JSTOR}
+@article{AFCAPSresults,
+  title     = {Primary prevention of acute coronary events with lovastatin in men and women with average cholesterol levels: results of AFCAPS/TexCAPS},
+  author    = {Downs, John R and Clearfield, Michael and Weis, Stephen and Whitney, Edwin and Shapiro, Deborah R and Beere, Polly A and Langendorfer, Alexandra and Stein, Evan A and Kruyer, William and Gotto Jr, Antonio M and others},
+  journal   = {Journal of the American Medical Association},
+  volume    = {279},
+  number    = {20},
+  pages     = {1615--1622},
+  year      = {1998},
+  publisher = {American Medical Association}
 }
 @article{AHRKalbfleisch1981,
   title     = {Estimation of the average hazard ratio},
@@ -53,6 +27,16 @@
   pages     = {105--112},
   year      = {1981},
   publisher = {Oxford University Press}
+}
+@article{AHRLeon2020,
+  title     = {On weighted log-rank combination tests and companion Cox model estimators},
+  author    = {Le{\'o}n, Larry F and Lin, Ray and Anderson, Keaven M},
+  journal   = {Statistics in Biosciences},
+  volume    = {12},
+  number    = {2},
+  pages     = {225--245},
+  year      = {2020},
+  publisher = {Springer}
 }
 @article{AHRRauch2018,
   title     = {The Average Hazard Ratio---A Good Effect Measure for Time-to-event Endpoints when the Proportional Hazard Assumption is Violated?},
@@ -74,14 +58,80 @@
   year      = {2009},
   publisher = {Wiley Online Library}
 }
-@article{Hasegawa2016,
-  title   = {"Group sequential monitoring based on the weighted log-rank test statistic with the Fleming--Harrington class of weights in cancer vaccine studies"},
-  author  = {Hasegawa, Takahiro},
-  journal = {Pharmaceutical Statistics},
-  volume  = {15},
-  number  = {5},
-  pages   = {412--419},
-  year    = {2016}
+@misc{anderson2009gsdesign,
+  title  = {gsDesign: An R Package for Designing Group Sequential Clinical Trials, Version 2.0 Manual},
+  author = {Anderson, Keaven M},
+  year   = {2009}
+}
+@article{atezoSCLC1L,
+  title     = {First-line atezolizumab plus chemotherapy in extensive-stage small-cell lung cancer},
+  author    = {Horn, Leora and Mansfield, Aaron S and Szcz{\k{e}}sna, Aleksandra and Havel, Libor and Krzakowski, Maciej and Hochmair, Maximilian J and Huemer, Florian and Losonczy, Gy{\"o}rgy and Johnson, Melissa L and Nishio, Makoto and others},
+  journal   = {New England Journal of Medicine},
+  volume    = {379},
+  number    = {23},
+  pages     = {2220--2229},
+  year      = {2018},
+  publisher = {Mass Medical Soc}
+}
+@article{Cox1972,
+  title     = {Regression models and life-tables},
+  author    = {Cox, David R},
+  journal   = {Journal of the Royal Statistical Society: Series B (Methodological)},
+  volume    = {34},
+  number    = {2},
+  pages     = {187--202},
+  year      = {1972},
+  publisher = {Wiley Online Library}
+}
+@article{deCastroGAMLSS,
+  title     = {A hands-on approach for fitting long-term survival models under the GAMLSS framework},
+  author    = {De Castro, Mario and Cancho, Vicente G and Rodrigues, Josemar},
+  journal   = {Computer Methods and Programs in Biomedicine},
+  volume    = {97},
+  number    = {2},
+  pages     = {168--177},
+  year      = {2010},
+  publisher = {Elsevier}
+}
+@article{ewell1997large,
+  title     = {The large sample distribution of the weighted log rank statistic under general local alternatives},
+  author    = {Ewell, Marian and Ibrahim, Joseph G},
+  journal   = {Lifetime Data Analysis},
+  volume    = {3},
+  number    = {1},
+  pages     = {5--12},
+  year      = {1997},
+  publisher = {Springer}
+}
+@article{EXAMINEdesign,
+  title     = {EXamination of cArdiovascular outcoMes with alogliptIN versus standard of carE in patients with type 2 diabetes mellitus and acute coronary syndrome (EXAMINE): a cardiovascular safety study of the dipeptidyl peptidase 4 inhibitor alogliptin in patients with type 2 diabetes with acute coronary syndrome},
+  author    = {White, William B and Bakris, George L and Bergenstal, Richard M and Cannon, Christopher P and Cushman, William C and Fleck, Penny and Heller, Simon and Mehta, Cyrus and Nissen, Steven E and Perez, Alfonso and others},
+  journal   = {American Heart Journal},
+  volume    = {162},
+  number    = {4},
+  pages     = {620--626},
+  year      = {2011},
+  publisher = {Elsevier}
+}
+
+@article{EXAMINEresults,
+  title     = {Alogliptin after acute coronary syndrome in patients with type 2 diabetes},
+  author    = {White, William B and Cannon, Christopher P and Heller, Simon R and Nissen, Steven E and Bergenstal, Richard M and Bakris, George L and Perez, Alfonso T and Fleck, Penny R and Mehta, Cyrus R and Kupfer, Stuart and others},
+  journal   = {New England Journal of Medicine},
+  volume    = {369},
+  pages     = {1327--1335},
+  year      = {2013},
+  publisher = {Mass Medical Soc}
+}
+@article{FHO,
+  title     = {Designs for group sequential tests},
+  author    = {Fleming, Thomas R and Harrington, David P and O'Brien, Peter C},
+  journal   = {Controlled Clinical Trials},
+  volume    = {5},
+  number    = {4},
+  pages     = {348--361},
+  year      = {1984},
+  publisher = {Elsevier}
 }
 @article{FHRhoGamma,
   title     = {A class of rank test procedures for censored survival data},
@@ -93,39 +143,129 @@
   year      = {1982},
   publisher = {Oxford University Press}
 }
-@article{Lakatos,
-  author  = {Lakatos, Edward},
-  title   = {Sample size based on the log-rank statistic in complex clinical trials},
-  journal = {Biometrics},
-  volume  = {44},
-  year    = {1988},
-  pages   = {229-241}
-}
-@article{Cox1972,
-  author  = {David R. Cox},
-  title   = {Regression models and life-tables},
-  journal = {Journal of the Royal Statistics Society, Series B},
-  volume  = {34},
-  year    = {1972},
-  pages   = {187-220}
-}
-@article{petologrank,
-  title     = {Asymptotically efficient rank invariant test procedures},
-  author    = {Peto, Richard and Peto, Julian},
-  journal   = {Journal of the Royal Statistical Society. Series A (General)},
-  pages     = {185--207},
-  year      = {1972},
+@article{Follmann1994MAMS,
+  title     = {Monitoring pairwise comparisons in multi-armed clinical trials},
+  author    = {Follmann, Dean A and Proschan, Michael A and Geller, Nancy L},
+  journal   = {Biometrics},
+  pages     = {325--336},
+  year      = {1994},
   publisher = {JSTOR}
 }
-@article{peto1977design,
-  title     = {Design and analysis of randomized clinical trials requiring prolonged observation of each patient. II. analysis and examples},
-  author    = {Peto, Richard and Pike, MCetal and Armitage, Philip and Breslow, Norman E and Cox, DR and Howard, SV and Mantel, N and McPherson, K and Peto, J and Smith, PG},
-  journal   = {British Journal of Cancer},
-  volume    = {35},
+@article{FreidlinKorn2019,
+  title     = {Methods for accommodating nonproportional hazards in clinical trials: ready for the primary analysis?},
+  author    = {Freidlin, Boris and Korn, Edward L},
+  journal   = {Journal of Clinical Oncology},
+  volume    = {37},
+  number    = {35},
+  pages     = {3455},
+  year      = {2019},
+  publisher = {American Society of Clinical Oncology}
+}
+@article{gordon1983discrete,
+  title     = {Discrete sequential boundaries for clinical trials},
+  author    = {Gordon Lan, KK and DeMets, David L},
+  journal   = {Biometrika},
+  volume    = {70},
+  number    = {3},
+  pages     = {659--663},
+  year      = {1983},
+  publisher = {Oxford University Press}
+}
+@article{Grambsch1994,
+  title     = {Proportional hazards tests and diagnostics based on weighted residuals},
+  author    = {Grambsch, Patricia M and Therneau, Terry M},
+  journal   = {Biometrika},
+  volume    = {81},
+  number    = {3},
+  pages     = {515--526},
+  year      = {1994},
+  publisher = {Oxford University Press}
+}
+@article{gray1989linear,
+  title     = {A linear rank test for use when the main interest is in differences in cure rates},
+  author    = {Gray, Robert J and Tsiatis, Anastasios A},
+  journal   = {Biometrics},
+  pages     = {899--904},
+  year      = {1989},
+  publisher = {JSTOR}
+}
+@misc{gsDesign2,
+  author       = {Keaven M. Anderson},
+  title        = {Group Sequential Design Under Non-Proportional Hazards},
+  year         = {2020},
+  publisher    = {Merck & Co., Inc.},
+  journal      = {GitHub repository},
+  howpublished = {\url{https://github.com/Merck/gsDesign2}}
+}
+@misc{gsdmvn,
+  author       = {Keaven M. Anderson},
+  title        = {Group sequential design with non-constant effect},
+  year         = {2020},
+  publisher    = {Merck & Co., Inc.},
+  journal      = {GitHub repository},
+  howpublished = {\url{https://github.com/Merck/gsdmvn}}
+}
+@article{Hasegawa2014,
+  title     = {Sample size determination for the weighted log-rank test with the Fleming--Harrington class of weights in cancer vaccine studies},
+  author    = {Hasegawa, Takahiro},
+  journal   = {Pharmaceutical Statistics},
+  volume    = {13},
+  number    = {2},
+  pages     = {128--135},
+  year      = {2014},
+  publisher = {Wiley Online Library}
+}
+@article{Hasegawa2016,
+  title   = {"Group sequential monitoring based on the weighted log-rank test statistic with the Fleming--Harrington class of weights in cancer vaccine studies"},
+  author  = {Hasegawa, Takahiro},
+  journal = {Pharmaceutical Statistics},
+  volume  = {15},
+  number  = {5},
+  pages   = {412--419},
+  year    = {2016}
+}
+@article{haybittle1971repeated,
+  title     = {Repeated assessment of results in clinical trials of cancer treatment},
+  author    = {Haybittle, JL},
+  journal   = {The British Journal of Radiology},
+  volume    = {44},
+  number    = {526},
+  pages     = {793--797},
+  year      = {1971},
+  publisher = {The British Institute of Radiology}
+}
+@misc{hellmann2017estimating,
+  title     = {Estimating long-term survival of PD-L1-expressing, previously treated, non-small cell lung cancer patients who received pembrolizumab in KEYNOTE-001 and-010},
+  author    = {Hellmann, Matthew David and Ma, Junshui and Garon, Edward B and Hui, Rina and Gandhi, Leena and Soria, Jean-Charles and Anderson, Keaven M and Lubiniecki, Gregory M and Piperdi, Bilal and Herbst, Roy S},
+  year      = {2017},
+  publisher = {American Society of Clinical Oncology}
+}
+@article{HRhazards2010,
+  title     = {The hazards of hazard ratios},
+  author    = {Hern{\'a}n, Miguel A},
+  journal   = {Epidemiology},
+  volume    = {21},
   number    = {1},
-  pages     = {1--39},
-  year      = {1977},
-  publisher = {Nature Publishing Group}
+  pages     = {13},
+  year      = {2010},
+  publisher = {NIH Public Access}
+}
+@article{HSD,
+  title     = {Group sequential designs using a family of type I error probability spending functions},
+  author    = {Hwang, Irving K and Shih, Weichung J and De Cani, John S},
+  journal   = {Statistics in Medicine},
+  volume    = {9},
+  number    = {12},
+  pages     = {1439--1445},
+  year      = {1990},
+  publisher = {Wiley Online Library}
+}
+@book{JTBook,
+  author    = {Jennison, Christopher and Turnbull, Bruce W.},
+  title     = {Group Sequential Methods with Applications to Clinical Trials},
+  publisher = {Chapman and Hall/CRC},
+  address   = {Boca Raton, FL},
+  year      = {2000}
 }
 @article{KaplanMeier,
   author    = {E. L.   Kaplan  and  Paul   Meier},
@@ -150,154 +290,15 @@
   year      = {2016},
   publisher = {StataCorp LP}
 }
-
-@article{Schemper1992,
-  title     = {Cox analysis of survival data with non-proportional hazard functions},
-  author    = {Schemper, Michael},
-  journal   = {The Statistician},
-  pages     = {455--465},
-  year      = {1992},
-  publisher = {JSTOR}
-}
-@article{ewell1997large,
-  title     = {The large sample distribution of the weighted log rank statistic under general local alternatives},
-  author    = {Ewell, Marian and Ibrahim, Joseph G},
-  journal   = {Lifetime Data Analysis},
-  volume    = {3},
-  number    = {1},
-  pages     = {5--12},
-  year      = {1997},
-  publisher = {Springer}
-}
-@article{gray1989linear,
-  title     = {A linear rank test for use when the main interest is in differences in cure rates},
-  author    = {Gray, Robert J and Tsiatis, Anastasios A},
-  journal   = {Biometrics},
-  pages     = {899--904},
-  year      = {1989},
-  publisher = {JSTOR}
-}
-@article{wu2017sample,
-  title     = {Sample size calculation for testing differences between cure rates with the optimal log-rank test},
-  author    = {Wu, Jianrong},
-  journal   = {Journal of Biopharmaceutical Statistics},
-  volume    = {27},
-  number    = {1},
-  pages     = {124--134},
-  year      = {2017},
-  publisher = {Taylor \& Francis}
-}
-@article{LachinFoulkes,
-  author  = {Lachin, John M. and Foulkes, Mary A.},
-  title   = {Evaluation of sample size and power for analyses of survival with allowance for nonuniform patient entry, losses to follow-up, noncompliance, and stratification},
-  journal = {Biometrics},
-  volume  = {42},
-  year    = {1986},
-  pages   = {507-519}
-}
-@article{Schoenfeld1981,
-  title     = {The asymptotic properties of nonparametric tests for comparing survival distributions},
-  author    = {Schoenfeld, David},
-  journal   = {Biometrika},
-  volume    = {68},
-  number    = {1},
-  pages     = {316--319},
-  year      = {1981},
-  publisher = {Oxford University Press}
-}
-@article{Schoenfeld1982,
-  title     = {Partial residuals for the proportional hazards regression model},
-  author    = {Schoenfeld, David},
-  journal   = {Biometrika},
-  volume    = {69},
-  number    = {1},
-  pages     = {239--241},
-  year      = {1982},
-  publisher = {Oxford University Press}
-}
-@article{Mukhopadhyay2020,
-  title     = {Statistical and practical considerations in designing of immuno-oncology trials},
-  author    = {Mukhopadhyay, Pralay and Huang, Wenmei and Metcalfe, Paul and {\"O}hrn, Fredrik and 
-               Jenner, Mary and Stone, Andrew},
-  journal   = {Journal of Biopharmaceutical Statistics},
-  pages     = {1--17},
-  year      = {2020},
-  publisher = {Taylor \& Francis}
-}
-@article{Tsiatis,
-  author  = {Anastasios A. Tsiatis},
-  title   = {Repeated significance testing for a general class of statistics use in censored survival analysis},
-  journal = {Journal of the American Statistical Association},
-  volume  = {77},
-  pages   = {855-861},
-  year    = {1982}
-}
-@article{HRhazards2010,
-  title     = {The hazards of hazard ratios},
-  author    = {Hern{\'a}n, Miguel A},
-  journal   = {Epidemiology},
-  volume    = {21},
-  number    = {1},
-  pages     = {13},
-  year      = {2010},
-  publisher = {NIH Public Access}
-}
-@book{JTBook,
-  author    = {Jennison, Christopher and Turnbull, Bruce W.},
-  title     = {Group Sequential Methods with Applications to Clinical Trials},
-  publisher = {Chapman and Hall/CRC},
-  address   = {Boca Raton, FL},
-  year      = {2000}
-}
-@misc{simtrial,
-  author       = {Keaven M. Anderson},
-  title        = {Clinical Trial Simulation},
-  year         = {2020},
-  publisher    = {Merck & Co., Inc.},
-  journal      = {GitHub repository},
-  howpublished = {\url{https://github.com/Merck/simtrial}}
-}
-@misc{gsDesign2,
-  author       = {Keaven M. Anderson},
-  title        = {Group Sequential Design Under Non-Proportional Hazards},
-  year         = {2020},
-  publisher    = {Merck & Co., Inc.},
-  journal      = {GitHub repository},
-  howpublished = {\url{https://github.com/Merck/gsDesign2}}
-}
-@misc{gsdmvn,
-  author       = {Keaven M. Anderson},
-  title        = {Group sequential design with non-constant effect},
-  year         = {2020},
-  publisher    = {Merck & Co., Inc.},
-  journal      = {GitHub repository},
-  howpublished = {\url{https://github.com/Merck/gsdmvn}}
-}
-@book{Klein2006,
-  title     = {Survival analysis: techniques for censored and truncated data},
-  author    = {Klein, John P and Moeschberger, Melvin L},
-  year      = {2006},
-  publisher = {Springer Science \& Business Media}
-}
-@article{Cox1972,
-  title     = {Regression models and life-tables},
-  author    = {Cox, David R},
-  journal   = {Journal of the Royal Statistical Society: Series B (Methodological)},
-  volume    = {34},
-  number    = {2},
-  pages     = {187--202},
-  year      = {1972},
-  publisher = {Wiley Online Library}
-}
-@article{Grambsch1994,
-  title     = {Proportional hazards tests and diagnostics based on weighted residuals},
-  author    = {Grambsch, Patricia M and Therneau, Terry M},
-  journal   = {Biometrika},
-  volume    = {81},
+@article{karrison2016versatile,
+  title     = {Versatile tests for comparing survival curves based on weighted log-rank statistics},
+  author    = {Karrison, Theodore G},
+  journal   = {The Stata Journal},
+  volume    = {16},
   number    = {3},
-  pages     = {515--526},
-  year      = {1994},
-  publisher = {Oxford University Press}
+  pages     = {678--690},
+  year      = {2016},
+  publisher = {SAGE Publications Sage CA: Los Angeles, CA}
 }
 @article{KEYNOTE040,
   title     = {Pembrolizumab versus methotrexate, docetaxel, or cetuximab for recurrent or metastatic head-and-neck squamous cell carcinoma (KEYNOTE-040): a randomised, open-label, phase 3 study},
@@ -319,6 +320,17 @@
   year      = {2019},
   publisher = {Elsevier}
 }
+@article{KEYNOTE048,
+  title     = {Pembrolizumab alone or with chemotherapy versus cetuximab with chemotherapy for recurrent or metastatic squamous cell carcinoma of the head and neck (KEYNOTE-048): a randomised, open-label, phase 3 study},
+  author    = {Burtness, Barbara and Harrington, Kevin J and Greil, Richard and Souli{\`e}res, Denis and Tahara, Makoto and de Castro Jr, Gilberto and Psyrri, Amanda and Bast{\'e}, Neus and Neupane, Prakash and Bratland, {\AA}se and others},
+  journal   = {The Lancet},
+  volume    = {394},
+  number    = {10212},
+  pages     = {1915--1928},
+  year      = {2019},
+  publisher = {Elsevier}
+}
+
 @article{KEYNOTE061,
   title     = {Pembrolizumab versus paclitaxel for previously treated, advanced gastric or gastro-oesophageal junction cancer (KEYNOTE-061): a randomised, open-label, controlled, phase 3 trial},
   author    = {Shitara, Kohei and {\"O}zg{\"u}ro{\u{g}}lu, Mustafa and Bang, Yung-Jue and Di Bartolomeo, Maria and Mandal{\`a}, Mario and Ryu, Min-Hee and Fornaro, Lorenzo and Olesi{\'n}ski, Tomasz and Caglevic, Christian and Chung, Hyun C and others},
@@ -339,33 +351,15 @@
   year      = {2018},
   publisher = {Mass Medical Soc}
 }
-@article{simva4s,
-  title     = {Cholesterol-lowering therapy in women and elderly patients with myocardial infarction or angina pectoris: findings from the Scandinavian Simvastatin Survival Study (4S)},
-  author    = {Miettinen, Tatu A and Pyörälä, Kalevi and Olsson, Anders G and Musliner, Thomas A and Cook, Thomas J and Faergeman, Ole and Berg, Kåre and Pedersen, Terje and Kjekshus, John and Group, for the Scandinavian Simvastatin Study},
-  journal   = {Circulation},
-  volume    = {96},
-  number    = {12},
-  pages     = {4211--4218},
-  year      = {1997},
-  publisher = {Am Heart Assoc}
-}
-@article{LanDeMets,
-  author  = {Lan, K.~K.~G. and DeMets, David L.},
-  title   = {Discrete sequential boundaries for clinical trials},
-  journal = {Biometrika},
-  volume  = {70},
-  year    = {1983},
-  pages   = {659-663}
-}
-
-@article{LanDeMets1989,
-  author  = {Lan, K.~K.~G. and DeMets, David L.},
-  title   = {Group sequential procedures: Calendar versus information time},
-  journal = {Statistics in Medicine},
-  volume  = {8},
-  year    = {1989},
-  pages   = {1191-1198},
-  doi     = {10.1002/sim.4780081003}
+@article{KEYNOTE522,
+  title     = {Pembrolizumab for early triple-negative breast cancer},
+  author    = {Schmid, Peter and Cortes, Javier and Pusztai, Lajos and McArthur, Heather and K{\"u}mmel, Sherko and Bergh, Jonas and Denkert, Carsten and Park, Yeon Hee and Hui, Rina and Harbeck, Nadia and others},
+  journal   = {New England Journal of Medicine},
+  volume    = {382},
+  number    = {9},
+  pages     = {810--821},
+  year      = {2020},
+  publisher = {Mass Medical Soc}
 }
 @article{KEYNOTE604,
   title     = {Pembrolizumab or placebo plus etoposide and platinum as first-line therapy for extensive-stage small-cell lung cancer: randomized, double-blind, phase III KEYNOTE-604 study},
@@ -377,62 +371,136 @@
   year      = {2020},
   publisher = {American Society of Clinical Oncology}
 }
-@article{atezoSCLC1L,
-  title     = {First-line atezolizumab plus chemotherapy in extensive-stage small-cell lung cancer},
-  author    = {Horn, Leora and Mansfield, Aaron S and Szcz{\k{e}}sna, Aleksandra and Havel, Libor and Krzakowski, Maciej and Hochmair, Maximilian J and Huemer, Florian and Losonczy, Gy{\"o}rgy and Johnson, Melissa L and Nishio, Makoto and others},
-  journal   = {New England Journal of Medicine},
-  volume    = {379},
-  number    = {23},
-  pages     = {2220--2229},
-  year      = {2018},
-  publisher = {Mass Medical Soc}
-}
-@article{Ye2013,
-  title     = {A group sequential Holm procedure with multiple primary endpoints},
-  author    = {Ye, Yining and Li, Ai and Liu, Lingyun and Yao, Bin},
-  journal   = {Statistics in Medicine},
-  volume    = {32},
-  number    = {7},
-  pages     = {1112--1124},
-  year      = {2013},
-  publisher = {Wiley Online Library}
-}
-@article{MaurerBretz2013,
-  author  = {Willi Maurer and Frank Bretz},
-  title   = {Multiple testing in group sequential trials using graphical approaches},
-  journal = {Statistics in Biopharmaceutical Research},
-  volume  = {5},
-  year    = {2013},
-  pages   = {311-320},
-  doi     = {10.1080/19466315.2013.807748}
-}
-
-@article{KEYNOTE048,
-  title     = {Pembrolizumab alone or with chemotherapy versus cetuximab with chemotherapy for recurrent or metastatic squamous cell carcinoma of the head and neck (KEYNOTE-048): a randomised, open-label, phase 3 study},
-  author    = {Burtness, Barbara and Harrington, Kevin J and Greil, Richard and Souli{\`e}res, Denis and Tahara, Makoto and de Castro Jr, Gilberto and Psyrri, Amanda and Bast{\'e}, Neus and Neupane, Prakash and Bratland, {\AA}se and others},
-  journal   = {The Lancet},
-  volume    = {394},
-  number    = {10212},
-  pages     = {1915--1928},
-  year      = {2019},
-  publisher = {Elsevier}
-}
-@article{Follmann1994MAMS,
-  title     = {Monitoring pairwise comparisons in multi-armed clinical trials},
-  author    = {Follmann, Dean A and Proschan, Michael A and Geller, Nancy L},
+@article{kim1990study,
+  title     = {Study duration for clinical trials with survival response and early stopping rule},
+  author    = {Kim, Kyungmann and Tsiatis, Anastasios A},
   journal   = {Biometrics},
-  pages     = {325--336},
-  year      = {1994},
+  pages     = {81--92},
+  year      = {1990},
   publisher = {JSTOR}
 }
-@article{YungLiu,
-  title     = {Sample size and power for the weighted log-rank test and Kaplan-Meier based tests with allowance for nonproportional hazards},
-  author    = {Yung, Godwin and Liu, Yi},
+
+@article{KimTsiatis,
+  author  = {Kyungmann Kim  and Anastasios A. Tsiatis},
+  title   = {Study duration for clinical trials with survival response and early stopping rule.},
+  journal = {Biometrics},
+  volume  = {46},
+  year    = {1990},
+  pages   = {81-92}
+}
+@book{Klein2006,
+  title     = {Survival analysis: techniques for censored and truncated data},
+  author    = {Klein, John P and Moeschberger, Melvin L},
+  year      = {2006},
+  publisher = {Springer Science \& Business Media}
+}
+@article{lachin1981introduction,
+  title     = {Introduction to sample size determination and power analysis for clinical trials},
+  author    = {Lachin, John M},
+  journal   = {Controlled Clinical Trials},
+  volume    = {2},
+  number    = {2},
+  pages     = {93--113},
+  year      = {1981},
+  publisher = {Elsevier}
+}
+@article{lachin1986evaluation,
+  title     = {Evaluation of sample size and power for analyses of survival with allowance for nonuniform patient entry, losses to follow-up, noncompliance, and stratification},
+  author    = {Lachin, John M and Foulkes, Mary A},
   journal   = {Biometrics},
-  volume    = {76},
-  number    = {3},
-  pages     = {939--950},
+  pages     = {507--519},
+  year      = {1986},
+  publisher = {JSTOR}
+}
+@article{lachin2005review,
+  title     = {A review of methods for futility stopping based on conditional power},
+  author    = {Lachin, John M},
+  journal   = {Statistics in Medicine},
+  volume    = {24},
+  number    = {18},
+  pages     = {2747--2764},
+  year      = {2005},
+  publisher = {Wiley Online Library}
+}
+@article{LachinFoulkes,
+  author  = {Lachin, John M. and Foulkes, Mary A.},
+  title   = {Evaluation of sample size and power for analyses of survival with allowance for nonuniform patient entry, losses to follow-up, noncompliance, and stratification},
+  journal = {Biometrics},
+  volume  = {42},
+  year    = {1986},
+  pages   = {507-519}
+}
+@article{Lakatos,
+  author  = {Lakatos, Edward},
+  title   = {Sample size based on the log-rank statistic in complex clinical trials},
+  journal = {Biometrics},
+  volume  = {44},
+  year    = {1988},
+  pages   = {229-241}
+}
+@article{LanDeMets,
+  author  = {Lan, K.~K.~G. and DeMets, David L.},
+  title   = {Discrete sequential boundaries for clinical trials},
+  journal = {Biometrika},
+  volume  = {70},
+  year    = {1983},
+  pages   = {659-663}
+}
+@article{LanDeMets1989,
+  author  = {Lan, K.~K.~G. and DeMets, David L.},
+  title   = {Group sequential procedures: Calendar versus information time},
+  journal = {Statistics in Medicine},
+  volume  = {8},
+  year    = {1989},
+  pages   = {1191-1198},
+  doi     = {10.1002/sim.4780081003}
+}
+@article{lin2020alternative,
+  title     = {Alternative Analysis Methods for Time to Event Endpoints Under Nonproportional Hazards: A Comparative Analysis},
+  author    = {Lin, Ray S and Lin, Ji and Roychoudhury, Satrajit and Anderson, Keaven M and Hu, Tianle and Huang, Bo and Leon, Larry F and Liao, Jason JZ and Liu, Rong and Luo, Xiaodong and others},
+  journal   = {Statistics in Biopharmaceutical Research},
+  volume    = {12},
+  number    = {2},
+  pages     = {187--198},
   year      = {2020},
+  publisher = {Taylor \& Francis}
+}
+@article{lu2020statistical,
+  title     = {Statistical Considerations for Sequential Analysis of the Restricted Mean Survival Time for Randomized Clinical Trials},
+  author    = {Ying Lu and Tian Lu},
+  journal   = {Statistics in Biopharmaceutical Research},
+  pages     = {1--9},
+  year      = {2020},
+  publisher = {Taylor \& Francis}
+}
+@article{luo2019design,
+  title     = {Design and monitoring of survival trials in complex scenarios},
+  author    = {Luo, Xiaodong and Mao, Xuezhou and Chen, Xun and Qiu, Junshan and Bai, Steven and Quan, Hui},
+  journal   = {Statistics in Medicine},
+  volume    = {38},
+  number    = {2},
+  pages     = {192--209},
+  year      = {2019},
+  publisher = {Wiley Online Library}
+}
+@article{luo2019rmst,
+  title     = {Design and monitoring of survival trials based on restricted mean survival times},
+  author    = {Luo, Xiaodong and Huang, Bo and Quan, Hui},
+  journal   = {Clinical Trials},
+  volume    = {16},
+  number    = {6},
+  pages     = {616--625},
+  year      = {2019},
+  publisher = {SAGE Publications Sage UK: London, England}
+}
+@article{magirr2019modestly,
+  title     = {Modestly weighted logrank tests},
+  author    = {Magirr, Dominic and Burman, Carl-Fredrik},
+  journal   = {Statistics in Medicine},
+  volume    = {38},
+  number    = {20},
+  pages     = {3782--3790},
+  year      = {2019},
   publisher = {Wiley Online Library}
 }
 @article{MagirrBurman,
@@ -445,33 +513,30 @@
   year      = {2019},
   publisher = {Wiley Online Library}
 }
-@article{FreidlinKorn2019,
-  title     = {Methods for accommodating nonproportional hazards in clinical trials: ready for the primary analysis?},
-  author    = {Freidlin, Boris and Korn, Edward L},
-  journal   = {Journal of Clinical Oncology},
-  volume    = {37},
-  number    = {35},
-  pages     = {3455},
-  year      = {2019},
-  publisher = {American Society of Clinical Oncology}
+@article{MAMS,
+  author  = {Pranab Ghosh and Lingyn Liu and P. Senchaudhuri and Ping Gao and Cyrus Mehta},
+  title   = {Design and monitoring of multi-arm multi-stage clinical trials},
+  journal = {Biometrics},
+  year    = {2017},
+  doi     = {10.1111/biom.12687}
 }
-@article{NPHWG2021Design,
-  title     = {Robust design and analysis of clinical trials with non-proportional hazards: a straw man guidance from a cross-pharma working group},
-  author    = {Roychoudhury, Satrajit and Anderson, Keaven M and Ye, Jiabu and Mukhopadhyay, Pralay},
-  journal   = {Statistics in Biopharmaceutical Research},
-  pages     = {1--37},
-  year      = {2021},
+@article{MaurerBretz2013,
+  author  = {Willi Maurer and Frank Bretz},
+  title   = {Multiple testing in group sequential trials using graphical approaches},
+  journal = {Statistics in Biopharmaceutical Research},
+  volume  = {5},
+  year    = {2013},
+  pages   = {311-320},
+  doi     = {10.1080/19466315.2013.807748}
+}
+@article{Mukhopadhyay2020,
+  title     = {Statistical and practical considerations in designing of immuno-oncology trials},
+  author    = {Mukhopadhyay, Pralay and Huang, Wenmei and Metcalfe, Paul and {\"O}hrn, Fredrik and 
+               Jenner, Mary and Stone, Andrew},
+  journal   = {Journal of Biopharmaceutical Statistics},
+  pages     = {1--17},
+  year      = {2020},
   publisher = {Taylor \& Francis}
-}
-@article{HSD,
-  title     = {Group sequential designs using a family of type I error probability spending functions},
-  author    = {Hwang, Irving K and Shih, Weichung J and De Cani, John S},
-  journal   = {Statistics in Medicine},
-  volume    = {9},
-  number    = {12},
-  pages     = {1439--1445},
-  year      = {1990},
-  publisher = {Wiley Online Library}
 }
 @article{NPHWG2020sim,
   title     = {Alternative analysis methods for time to event endpoints under nonproportional hazards: a comparative analysis},
@@ -483,13 +548,181 @@
   year      = {2020},
   publisher = {Taylor \& Francis}
 }
-@article{MAMS,
-  author  = {Pranab Ghosh and Lingyn Liu and P. Senchaudhuri and Ping Gao and Cyrus Mehta},
-  title   = {Design and monitoring of multi-arm multi-stage clinical trials},
-  journal = {Biometrics},
-  year    = {2017},
-  doi     = {10.1111/biom.12687}
+
+@article{NPHWG2021Design,
+  title     = {Robust design and analysis of clinical trials with non-proportional hazards: a straw man guidance from a cross-pharma working group},
+  author    = {Roychoudhury, Satrajit and Anderson, Keaven M and Ye, Jiabu and Mukhopadhyay, Pralay},
+  journal   = {Statistics in Biopharmaceutical Research},
+  pages     = {1--37},
+  year      = {2021},
+  publisher = {Taylor \& Francis}
 }
+@article{o1979multiple,
+  title     = {A multiple testing procedure for clinical trials},
+  author    = {O'Brien, Peter C and Fleming, Thomas R},
+  journal   = {Biometrics},
+  pages     = {549--556},
+  year      = {1979},
+  publisher = {JSTOR}
+}
+@article{peto1977design,
+  title     = {Design and analysis of randomized clinical trials requiring prolonged observation of each patient. II. analysis and examples},
+  author    = {Peto, Richard and Pike, MCetal and Armitage, Philip and Breslow, Norman E and Cox, DR and Howard, SV and Mantel, N and McPherson, K and Peto, J and Smith, PG},
+  journal   = {British Journal of Cancer},
+  volume    = {35},
+  number    = {1},
+  pages     = {1--39},
+  year      = {1977},
+  publisher = {Nature Publishing Group}
+}
+@article{petologrank,
+  title     = {Asymptotically efficient rank invariant test procedures},
+  author    = {Peto, Richard and Peto, Julian},
+  journal   = {Journal of the Royal Statistical Society. Series A (General)},
+  pages     = {185--207},
+  year      = {1972},
+  publisher = {JSTOR}
+}
+=======
+
+@article{pocock1977group,
+  title     = {Group sequential methods in the design and analysis of clinical trials},
+  author    = {Pocock, Stuart J},
+  journal   = {Biometrika},
+  volume    = {64},
+  number    = {2},
+  pages     = {191--199},
+  year      = {1977},
+  publisher = {Oxford University Press}
+}
+
+@article{scharfstein1997semiparametric,
+  title     = {Semiparametric efficiency and its implication on the design and analysis of group-sequential studies},
+  author    = {Scharfstein, Daniel O and Tsiatis, Anastasios A and Robins, James M},
+  journal   = {Journal of the American Statistical Association},
+  volume    = {92},
+  number    = {440},
+  pages     = {1342--1350},
+  year      = {1997},
+  publisher = {Taylor \& Francis Group}
+}
+
+@article{Schemper1992,
+  title     = {Cox analysis of survival data with non-proportional hazard functions},
+  author    = {Schemper, Michael},
+  journal   = {The Statistician},
+  pages     = {455--465},
+  year      = {1992},
+  publisher = {JSTOR}
+}
+
+@article{Schoenfeld1981,
+  title     = {The asymptotic properties of nonparametric tests for comparing survival distributions},
+  author    = {Schoenfeld, David},
+  journal   = {Biometrika},
+  volume    = {68},
+  number    = {1},
+  pages     = {316--319},
+  year      = {1981},
+  publisher = {Oxford University Press}
+}
+
+@article{Schoenfeld1982,
+  title     = {Partial residuals for the proportional hazards regression model},
+  author    = {Schoenfeld, David},
+  journal   = {Biometrika},
+  volume    = {69},
+  number    = {1},
+  pages     = {239--241},
+  year      = {1982},
+  publisher = {Oxford University Press}
+}
+
+@misc{simtrial,
+  author       = {Keaven M. Anderson},
+  title        = {Clinical Trial Simulation},
+  year         = {2020},
+  publisher    = {Merck & Co., Inc.},
+  journal      = {GitHub repository},
+  howpublished = {\url{https://github.com/Merck/simtrial}}
+}
+
+@article{simva4s,
+  title     = {Cholesterol-lowering therapy in women and elderly patients with myocardial infarction or angina pectoris: findings from the Scandinavian Simvastatin Survival Study (4S)},
+  author    = {Miettinen, Tatu A and Pyörälä, Kalevi and Olsson, Anders G and Musliner, Thomas A and Cook, Thomas J and Faergeman, Ole and Berg, Kåre and Pedersen, Terje and Kjekshus, John and Group, for the Scandinavian Simvastatin Study},
+  journal   = {Circulation},
+  volume    = {96},
+  number    = {12},
+  pages     = {4211--4218},
+  year      = {1997},
+  publisher = {Am Heart Assoc}
+}
+
+@article{SludWei,
+  title     = {Two-sample repeated significance tests based on the modified Wilcoxon statistic},
+  author    = {Slud, Eric and Wei, LJ},
+  journal   = {Journal of the American Statistical Association},
+  volume    = {77},
+  number    = {380},
+  pages     = {862--868},
+  year      = {1982},
+  publisher = {Taylor \& Francis}
+}
+
+@article{Tsiatis,
+  author  = {Anastasios A. Tsiatis},
+  title   = {Repeated significance testing for a general class of statistics use in censored survival analysis},
+  journal = {Journal of the American Statistical Association},
+  volume  = {77},
+  pages   = {855-861},
+  year    = {1982}
+}
+
+@book{tsiatis2007semiparametric,
+  title     = {Semiparametric theory and missing data},
+  author    = {Tsiatis, Anastasios},
+  year      = {2007},
+  publisher = {Springer Science \& Business Media}
+}
+
+@article{wang1987approximately,
+  title     = {Approximately optimal one-parameter boundaries for group sequential trials},
+  author    = {Wang, Samuel K and Tsiatis, Anastasios A},
+  journal   = {Biometrics},
+  pages     = {193--199},
+  year      = {1987},
+  publisher = {JSTOR}
+}
+
+@article{wang2019simulation,
+  title   = {A Simulation-free Group Sequential Design with Max-combo Tests in the Presence of Non-proportional Hazards},
+  author  = {Wang, Lili and Luo, Xiaodong and Zheng, Cheng},
+  journal = {arXiv preprint arXiv:1911.05684},
+  year    = {2019}
+}
+
+@article{wu2017sample,
+  title     = {Sample size calculation for testing differences between cure rates with the optimal log-rank test},
+  author    = {Wu, Jianrong},
+  journal   = {Journal of Biopharmaceutical Statistics},
+  volume    = {27},
+  number    = {1},
+  pages     = {124--134},
+  year      = {2017},
+  publisher = {Taylor \& Francis}
+}
+
+@article{Ye2013,
+  title     = {A group sequential Holm procedure with multiple primary endpoints},
+  author    = {Ye, Yining and Li, Ai and Liu, Lingyun and Yao, Bin},
+  journal   = {Statistics in Medicine},
+  volume    = {32},
+  number    = {7},
+  pages     = {1112--1124},
+  year      = {2013},
+  publisher = {Wiley Online Library}
+}
+
 @article{Yung2019,
   title     = {Sample size and power for the weighted log-rank test and Kaplan-Meier based tests with allowance for nonproportional hazards},
   author    = {Yung, Godwin and Liu, Yi},
@@ -497,70 +730,24 @@
   year      = {2019},
   publisher = {Wiley Online Library}
 }
-@article{AFCAPSdesign,
-  title     = {Design \& rationale of the Air Force/Texas coronary atherosclerosis prevention study (AFCAPS/TexCAPS)},
-  author    = {Downs, John R and Beere, Polly A and Whitney, Edwin and Clearfield, Michael and Weis, Stephen and Rochen, Jeffrey and Stein, Evan A and Shapiro, Deborah R and Langendorfer, Alexandra and Gotto Jr, Antonio M},
-  journal   = {The American Journal of Cardiology},
-  volume    = {80},
+
+@article{yung2019sample,
+  title     = {Sample size and power for the weighted log-rank test and Kaplan-Meier based tests with allowance for nonproportional hazards},
+  author    = {Yung, Godwin and Liu, Yi},
+  journal   = {Biometrics},
+  year      = {2019},
+  publisher = {Wiley Online Library}
+}
+
+@article{YungLiu,
+  title     = {Sample size and power for the weighted log-rank test and Kaplan-Meier based tests with allowance for nonproportional hazards},
+  author    = {Yung, Godwin and Liu, Yi},
+  journal   = {Biometrics},
+  volume    = {76},
   number    = {3},
-  pages     = {287--293},
-  year      = {1997},
-  publisher = {Elsevier}
-}
-@article{AFCAPSresults,
-  title     = {Primary prevention of acute coronary events with lovastatin in men and women with average cholesterol levels: results of AFCAPS/TexCAPS},
-  author    = {Downs, John R and Clearfield, Michael and Weis, Stephen and Whitney, Edwin and Shapiro, Deborah R and Beere, Polly A and Langendorfer, Alexandra and Stein, Evan A and Kruyer, William and Gotto Jr, Antonio M and others},
-  journal   = {Journal of the American Medical Association},
-  volume    = {279},
-  number    = {20},
-  pages     = {1615--1622},
-  year      = {1998},
-  publisher = {American Medical Association}
-}
-@article{EXAMINEresults,
-  title     = {Alogliptin after acute coronary syndrome in patients with type 2 diabetes},
-  author    = {White, William B and Cannon, Christopher P and Heller, Simon R and Nissen, Steven E and Bergenstal, Richard M and Bakris, George L and Perez, Alfonso T and Fleck, Penny R and Mehta, Cyrus R and Kupfer, Stuart and others},
-  journal   = {New England Journal of Medicine},
-  volume    = {369},
-  pages     = {1327--1335},
-  year      = {2013},
-  publisher = {Mass Medical Soc}
-}
-@article{EXAMINEdesign,
-  title     = {EXamination of cArdiovascular outcoMes with alogliptIN versus standard of carE in patients with type 2 diabetes mellitus and acute coronary syndrome (EXAMINE): a cardiovascular safety study of the dipeptidyl peptidase 4 inhibitor alogliptin in patients with type 2 diabetes with acute coronary syndrome},
-  author    = {White, William B and Bakris, George L and Bergenstal, Richard M and Cannon, Christopher P and Cushman, William C and Fleck, Penny and Heller, Simon and Mehta, Cyrus and Nissen, Steven E and Perez, Alfonso and others},
-  journal   = {American Heart Journal},
-  volume    = {162},
-  number    = {4},
-  pages     = {620--626},
-  year      = {2011},
-  publisher = {Elsevier}
-}
-@misc{hellmann2017estimating,
-  title     = {Estimating long-term survival of PD-L1-expressing, previously treated, non-small cell lung cancer patients who received pembrolizumab in KEYNOTE-001 and-010},
-  author    = {Hellmann, Matthew David and Ma, Junshui and Garon, Edward B and Hui, Rina and Gandhi, Leena and Soria, Jean-Charles and Anderson, Keaven M and Lubiniecki, Gregory M and Piperdi, Bilal and Herbst, Roy S},
-  year      = {2017},
-  publisher = {American Society of Clinical Oncology}
-}
-@article{deCastroGAMLSS,
-  title     = {A hands-on approach for fitting long-term survival models under the GAMLSS framework},
-  author    = {De Castro, Mario and Cancho, Vicente G and Rodrigues, Josemar},
-  journal   = {Computer Methods and Programs in Biomedicine},
-  volume    = {97},
-  number    = {2},
-  pages     = {168--177},
-  year      = {2010},
-  publisher = {Elsevier}
-}
-@article{KEYNOTE522,
-  title     = {Pembrolizumab for early triple-negative breast cancer},
-  author    = {Schmid, Peter and Cortes, Javier and Pusztai, Lajos and McArthur, Heather and K{\"u}mmel, Sherko and Bergh, Jonas and Denkert, Carsten and Park, Yeon Hee and Hui, Rina and Harbeck, Nadia and others},
-  journal   = {New England Journal of Medicine},
-  volume    = {382},
-  number    = {9},
-  pages     = {810--821},
+  pages     = {939--950},
   year      = {2020},
-  publisher = {Mass Medical Soc}
+  publisher = {Wiley Online Library}
 }
 @article{Zeng2006,
   title     = {Semiparametric transformation models for survival data with a cure fraction},
@@ -581,229 +768,4 @@
   pages     = {14--26},
   year      = {2018},
   publisher = {Oxford University Press}
-}
-
-@article{AHRKalbfleisch1981,
-  title     = {Estimation of the average hazard ratio},
-  author    = {Kalbfleisch, John D and Prentice, Ross L},
-  journal   = {Biometrika},
-  volume    = {68},
-  number    = {1},
-  pages     = {105--112},
-  year      = {1981},
-  publisher = {Oxford University Press}
-}
-@article{AHRRauch2018,
-  title     = {The Average Hazard Ratio--A Good Effect Measure for Time-to-event Endpoints when the Proportional Hazard Assumption is Violated?},
-  author    = {Rauch, Geraldine and Brannath, Werner and Br{\"u}ckner, Matthias and Kieser, Meinhard},
-  journal   = {Methods of Information in Medicine},
-  volume    = {57},
-  number    = {03},
-  pages     = {089--100},
-  year      = {2018},
-  publisher = {Schattauer GmbH}
-}
-@article{AHRSchemper2009,
-  title     = {The estimation of average hazard ratios by weighted Cox regression},
-  author    = {Schemper, Michael and Wakounig, Samo and Heinze, Georg},
-  journal   = {Statistics in Medicine},
-  volume    = {28},
-  number    = {19},
-  pages     = {2473--2489},
-  year      = {2009},
-  publisher = {Wiley Online Library}
-}
-@article{AHRLeon2020,
-  title     = {On weighted log-rank combination tests and companion Cox model estimators},
-  author    = {Le{\'o}n, Larry F and Lin, Ray and Anderson, Keaven M},
-  journal   = {Statistics in Biosciences},
-  volume    = {12},
-  number    = {2},
-  pages     = {225--245},
-  year      = {2020},
-  publisher = {Springer}
-}
-=======
-
-@article{yung2019sample,
-  title     = {Sample size and power for the weighted log-rank test and Kaplan-Meier based tests with allowance for nonproportional hazards},
-  author    = {Yung, Godwin and Liu, Yi},
-  journal   = {Biometrics},
-  year      = {2019},
-  publisher = {Wiley Online Library}
-}
-
-@article{lin2020alternative,
-  title     = {Alternative Analysis Methods for Time to Event Endpoints Under Nonproportional Hazards: A Comparative Analysis},
-  author    = {Lin, Ray S and Lin, Ji and Roychoudhury, Satrajit and Anderson, Keaven M and Hu, Tianle and Huang, Bo and Leon, Larry F and Liao, Jason JZ and Liu, Rong and Luo, Xiaodong and others},
-  journal   = {Statistics in Biopharmaceutical Research},
-  volume    = {12},
-  number    = {2},
-  pages     = {187--198},
-  year      = {2020},
-  publisher = {Taylor \& Francis}
-}
-
-@article{magirr2019modestly,
-  title     = {Modestly weighted logrank tests},
-  author    = {Magirr, Dominic and Burman, Carl-Fredrik},
-  journal   = {Statistics in Medicine},
-  volume    = {38},
-  number    = {20},
-  pages     = {3782--3790},
-  year      = {2019},
-  publisher = {Wiley Online Library}
-}
-
-@article{wang2019simulation,
-  title   = {A Simulation-free Group Sequential Design with Max-combo Tests in the Presence of Non-proportional Hazards},
-  author  = {Wang, Lili and Luo, Xiaodong and Zheng, Cheng},
-  journal = {arXiv preprint arXiv:1911.05684},
-  year    = {2019}
-}
-
-@article{scharfstein1997semiparametric,
-  title     = {Semiparametric efficiency and its implication on the design and analysis of group-sequential studies},
-  author    = {Scharfstein, Daniel O and Tsiatis, Anastasios A and Robins, James M},
-  journal   = {Journal of the American Statistical Association},
-  volume    = {92},
-  number    = {440},
-  pages     = {1342--1350},
-  year      = {1997},
-  publisher = {Taylor \& Francis Group}
-}
-
-@book{tsiatis2007semiparametric,
-  title     = {Semiparametric theory and missing data},
-  author    = {Tsiatis, Anastasios},
-  year      = {2007},
-  publisher = {Springer Science \& Business Media}
-}
-
-@article{lachin1981introduction,
-  title     = {Introduction to sample size determination and power analysis for clinical trials},
-  author    = {Lachin, John M},
-  journal   = {Controlled Clinical Trials},
-  volume    = {2},
-  number    = {2},
-  pages     = {93--113},
-  year      = {1981},
-  publisher = {Elsevier}
-}
-
-@misc{anderson2009gsdesign,
-  title  = {gsDesign: An R Package for Designing Group Sequential Clinical Trials, Version 2.0 Manual},
-  author = {Anderson, Keaven M},
-  year   = {2009}
-}
-
-@article{kim1990study,
-  title     = {Study duration for clinical trials with survival response and early stopping rule},
-  author    = {Kim, Kyungmann and Tsiatis, Anastasios A},
-  journal   = {Biometrics},
-  pages     = {81--92},
-  year      = {1990},
-  publisher = {JSTOR}
-}
-
-@article{luo2019design,
-  title     = {Design and monitoring of survival trials in complex scenarios},
-  author    = {Luo, Xiaodong and Mao, Xuezhou and Chen, Xun and Qiu, Junshan and Bai, Steven and Quan, Hui},
-  journal   = {Statistics in Medicine},
-  volume    = {38},
-  number    = {2},
-  pages     = {192--209},
-  year      = {2019},
-  publisher = {Wiley Online Library}
-}
-
-@article{lu2020statistical,
-  title     = {Statistical Considerations for Sequential Analysis of the Restricted Mean Survival Time for Randomized Clinical Trials},
-  author    = {Ying Lu and Tian Lu},
-  journal   = {Statistics in Biopharmaceutical Research},
-  pages     = {1--9},
-  year      = {2020},
-  publisher = {Taylor \& Francis}
-}
-
-@article{luo2019design,
-  title     = {Design and monitoring of survival trials based on restricted mean survival times},
-  author    = {Luo, Xiaodong and Huang, Bo and Quan, Hui},
-  journal   = {Clinical Trials},
-  volume    = {16},
-  number    = {6},
-  pages     = {616--625},
-  year      = {2019},
-  publisher = {SAGE Publications Sage UK: London, England}
-}
-
-@article{lachin2005review,
-  title     = {A review of methods for futility stopping based on conditional power},
-  author    = {Lachin, John M},
-  journal   = {Statistics in Medicine},
-  volume    = {24},
-  number    = {18},
-  pages     = {2747--2764},
-  year      = {2005},
-  publisher = {Wiley Online Library}
-}
-
-@article{wang1987approximately,
-  title     = {Approximately optimal one-parameter boundaries for group sequential trials},
-  author    = {Wang, Samuel K and Tsiatis, Anastasios A},
-  journal   = {Biometrics},
-  pages     = {193--199},
-  year      = {1987},
-  publisher = {JSTOR}
-}
-
-@article{pocock1977group,
-  title     = {Group sequential methods in the design and analysis of clinical trials},
-  author    = {Pocock, Stuart J},
-  journal   = {Biometrika},
-  volume    = {64},
-  number    = {2},
-  pages     = {191--199},
-  year      = {1977},
-  publisher = {Oxford University Press}
-}
-
-@article{o1979multiple,
-  title     = {A multiple testing procedure for clinical trials},
-  author    = {O'Brien, Peter C and Fleming, Thomas R},
-  journal   = {Biometrics},
-  pages     = {549--556},
-  year      = {1979},
-  publisher = {JSTOR}
-}
-
-@article{haybittle1971repeated,
-  title     = {Repeated assessment of results in clinical trials of cancer treatment},
-  author    = {Haybittle, JL},
-  journal   = {The British Journal of Radiology},
-  volume    = {44},
-  number    = {526},
-  pages     = {793--797},
-  year      = {1971},
-  publisher = {The British Institute of Radiology}
-}
-@article{SludWei,
-  title     = {Two-sample repeated significance tests based on the modified Wilcoxon statistic},
-  author    = {Slud, Eric and Wei, LJ},
-  journal   = {Journal of the American Statistical Association},
-  volume    = {77},
-  number    = {380},
-  pages     = {862--868},
-  year      = {1982},
-  publisher = {Taylor \& Francis}
-}
-@article{FHO,
-  title     = {Designs for group sequential tests},
-  author    = {Fleming, Thomas R and Harrington, David P and O'Brien, Peter C},
-  journal   = {Controlled Clinical Trials},
-  volume    = {5},
-  number    = {4},
-  pages     = {348--361},
-  year      = {1984},
-  publisher = {Elsevier}
 }

--- a/renv.lock
+++ b/renv.lock
@@ -1,10 +1,10 @@
 {
   "R": {
-    "Version": "4.1.1",
+    "Version": "4.1.2",
     "Repositories": [
       {
         "Name": "CRAN",
-        "URL": "https://packagemanager.rstudio.com/cran/latest"
+        "URL": "https://cran.rstudio.com"
       }
     ]
   },
@@ -13,754 +13,1121 @@
       "Package": "KMsurv",
       "Version": "0.1-5",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "aee647d15e5541ad44d157f7b78fda01"
+      "Repository": "CRAN",
+      "Hash": "aee647d15e5541ad44d157f7b78fda01",
+      "Requirements": []
     },
     "MASS": {
       "Package": "MASS",
       "Version": "7.3-54",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "0e59129db205112e3963904db67fd0dc"
+      "Hash": "0e59129db205112e3963904db67fd0dc",
+      "Requirements": []
     },
     "Matrix": {
       "Package": "Matrix",
-      "Version": "1.3-4",
+      "Version": "1.4-0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "4ed05e9c9726267e4a5872e09c04587c"
+      "Hash": "130c0caba175739d98f2963c6a407cf6",
+      "Requirements": [
+        "lattice"
+      ]
     },
     "R6": {
       "Package": "R6",
       "Version": "2.5.1",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "470851b6d5d0ac559e9d01bb352b4021"
+      "Repository": "CRAN",
+      "Hash": "470851b6d5d0ac559e9d01bb352b4021",
+      "Requirements": []
     },
     "RColorBrewer": {
       "Package": "RColorBrewer",
       "Version": "1.1-2",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "e031418365a7f7a766181ab5a41a5716"
+      "Repository": "CRAN",
+      "Hash": "e031418365a7f7a766181ab5a41a5716",
+      "Requirements": []
     },
     "Rcpp": {
       "Package": "Rcpp",
       "Version": "1.0.7",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "dab19adae4440ae55aa8a9d238b246bb"
+      "Repository": "CRAN",
+      "Hash": "dab19adae4440ae55aa8a9d238b246bb",
+      "Requirements": []
     },
     "askpass": {
       "Package": "askpass",
       "Version": "1.1",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "e8a22846fff485f0be3770c2da758713"
+      "Repository": "CRAN",
+      "Hash": "e8a22846fff485f0be3770c2da758713",
+      "Requirements": [
+        "sys"
+      ]
     },
     "backports": {
       "Package": "backports",
-      "Version": "1.3.0",
+      "Version": "1.4.1",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "194ad71f8ed59393272a0c4be2eac215"
+      "Repository": "CRAN",
+      "Hash": "c39fbec8a30d23e721980b8afb31984c",
+      "Requirements": []
     },
     "base64enc": {
       "Package": "base64enc",
       "Version": "0.1-3",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "543776ae6848fde2f48ff3816d0628bc"
+      "Repository": "CRAN",
+      "Hash": "543776ae6848fde2f48ff3816d0628bc",
+      "Requirements": []
     },
     "bitops": {
       "Package": "bitops",
       "Version": "1.0-7",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "b7d8d8ee39869c18d8846a184dd8a1af"
+      "Repository": "CRAN",
+      "Hash": "b7d8d8ee39869c18d8846a184dd8a1af",
+      "Requirements": []
     },
     "bookdown": {
       "Package": "bookdown",
       "Version": "0.24",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "3837766a1e1b527af25fa3e2d12a2800"
+      "Repository": "CRAN",
+      "Hash": "3837766a1e1b527af25fa3e2d12a2800",
+      "Requirements": [
+        "htmltools",
+        "jquerylib",
+        "knitr",
+        "rmarkdown",
+        "tinytex",
+        "xfun",
+        "yaml"
+      ]
     },
     "brio": {
       "Package": "brio",
-      "Version": "1.1.2",
+      "Version": "1.1.3",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "2f01e16ff9571fe70381c7b9ae560dc4"
+      "Repository": "CRAN",
+      "Hash": "976cf154dfb043c012d87cddd8bca363",
+      "Requirements": []
     },
     "bslib": {
       "Package": "bslib",
       "Version": "0.3.1",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "56ae7e1987b340186a8a5a157c2ec358"
+      "Repository": "CRAN",
+      "Hash": "56ae7e1987b340186a8a5a157c2ec358",
+      "Requirements": [
+        "htmltools",
+        "jquerylib",
+        "jsonlite",
+        "rlang",
+        "sass"
+      ]
     },
     "cachem": {
       "Package": "cachem",
       "Version": "1.0.6",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "648c5b3d71e6a37e3043617489a0a0e9"
+      "Repository": "CRAN",
+      "Hash": "648c5b3d71e6a37e3043617489a0a0e9",
+      "Requirements": [
+        "fastmap",
+        "rlang"
+      ]
     },
     "callr": {
       "Package": "callr",
       "Version": "3.7.0",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "461aa75a11ce2400245190ef5d3995df"
+      "Repository": "CRAN",
+      "Hash": "461aa75a11ce2400245190ef5d3995df",
+      "Requirements": [
+        "R6",
+        "processx"
+      ]
     },
     "checkmate": {
       "Package": "checkmate",
       "Version": "2.0.0",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "a667800d5f0350371bedeb8b8b950289"
+      "Repository": "CRAN",
+      "Hash": "a667800d5f0350371bedeb8b8b950289",
+      "Requirements": [
+        "backports"
+      ]
     },
     "cli": {
       "Package": "cli",
       "Version": "3.1.0",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "66a3834e54593c89d8beefb312347e58"
+      "Repository": "CRAN",
+      "Hash": "66a3834e54593c89d8beefb312347e58",
+      "Requirements": [
+        "glue"
+      ]
     },
     "colorspace": {
       "Package": "colorspace",
       "Version": "2.0-2",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "6baccb763ee83c0bd313460fdb8b8a84"
+      "Repository": "CRAN",
+      "Hash": "6baccb763ee83c0bd313460fdb8b8a84",
+      "Requirements": []
     },
     "commonmark": {
       "Package": "commonmark",
       "Version": "1.7",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "0f22be39ec1d141fd03683c06f3a6e67"
+      "Repository": "CRAN",
+      "Hash": "0f22be39ec1d141fd03683c06f3a6e67",
+      "Requirements": []
     },
     "corpcor": {
       "Package": "corpcor",
       "Version": "1.6.10",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "17ebe3b6d75d09c5bab3891880b34237"
+      "Repository": "CRAN",
+      "Hash": "17ebe3b6d75d09c5bab3891880b34237",
+      "Requirements": []
     },
     "cpp11": {
       "Package": "cpp11",
-      "Version": "0.4.1",
+      "Version": "0.4.2",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "70976176dfd7f179f212783aab2547b1"
+      "Repository": "CRAN",
+      "Hash": "fa53ce256cd280f468c080a58ea5ba8c",
+      "Requirements": []
     },
     "crayon": {
       "Package": "crayon",
       "Version": "1.4.2",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "0a6a65d92bd45b47b94b84244b528d17"
+      "Repository": "CRAN",
+      "Hash": "0a6a65d92bd45b47b94b84244b528d17",
+      "Requirements": []
     },
     "curl": {
       "Package": "curl",
       "Version": "4.3.2",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "022c42d49c28e95d69ca60446dbabf88"
+      "Repository": "CRAN",
+      "Hash": "022c42d49c28e95d69ca60446dbabf88",
+      "Requirements": []
     },
     "data.table": {
       "Package": "data.table",
       "Version": "1.14.2",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "36b67b5adf57b292923f5659f5f0c853"
+      "Repository": "CRAN",
+      "Hash": "36b67b5adf57b292923f5659f5f0c853",
+      "Requirements": []
     },
     "desc": {
       "Package": "desc",
       "Version": "1.4.0",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "28763d08fadd0b733e3cee9dab4e12fe"
+      "Repository": "CRAN",
+      "Hash": "28763d08fadd0b733e3cee9dab4e12fe",
+      "Requirements": [
+        "R6",
+        "crayon",
+        "rprojroot"
+      ]
     },
     "digest": {
       "Package": "digest",
-      "Version": "0.6.28",
+      "Version": "0.6.29",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "49b5c6e230bfec487b8917d5a0c77cca"
+      "Repository": "CRAN",
+      "Hash": "cf6b206a045a684728c3267ef7596190",
+      "Requirements": []
     },
     "downlit": {
       "Package": "downlit",
       "Version": "0.4.0",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "ba63dc9ab5a31f3209892437e40c5f60"
+      "Repository": "CRAN",
+      "Hash": "ba63dc9ab5a31f3209892437e40c5f60",
+      "Requirements": [
+        "brio",
+        "desc",
+        "digest",
+        "evaluate",
+        "fansi",
+        "memoise",
+        "rlang",
+        "vctrs",
+        "yaml"
+      ]
     },
     "dplyr": {
       "Package": "dplyr",
       "Version": "1.0.7",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "36f1ae62f026c8ba9f9b5c9a08c03297"
+      "Repository": "CRAN",
+      "Hash": "36f1ae62f026c8ba9f9b5c9a08c03297",
+      "Requirements": [
+        "R6",
+        "ellipsis",
+        "generics",
+        "glue",
+        "lifecycle",
+        "magrittr",
+        "pillar",
+        "rlang",
+        "tibble",
+        "tidyselect",
+        "vctrs"
+      ]
     },
     "ellipsis": {
       "Package": "ellipsis",
       "Version": "0.3.2",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "bb0eec2fe32e88d9e2836c2f73ea2077"
+      "Repository": "CRAN",
+      "Hash": "bb0eec2fe32e88d9e2836c2f73ea2077",
+      "Requirements": [
+        "rlang"
+      ]
     },
     "evaluate": {
       "Package": "evaluate",
       "Version": "0.14",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "ec8ca05cffcc70569eaaad8469d2a3a7"
+      "Repository": "CRAN",
+      "Hash": "ec8ca05cffcc70569eaaad8469d2a3a7",
+      "Requirements": []
     },
     "fansi": {
       "Package": "fansi",
-      "Version": "0.5.0",
+      "Version": "1.0.0",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "d447b40982c576a72b779f0a3b3da227"
+      "Repository": "CRAN",
+      "Hash": "ae34c3d1fdfac1566ca17c1b5d8f2613",
+      "Requirements": []
     },
     "farver": {
       "Package": "farver",
       "Version": "2.1.0",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "c98eb5133d9cb9e1622b8691487f11bb"
+      "Repository": "CRAN",
+      "Hash": "c98eb5133d9cb9e1622b8691487f11bb",
+      "Requirements": []
     },
     "fastmap": {
       "Package": "fastmap",
       "Version": "1.1.0",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "77bd60a6157420d4ffa93b27cf6a58b8"
+      "Repository": "CRAN",
+      "Hash": "77bd60a6157420d4ffa93b27cf6a58b8",
+      "Requirements": []
     },
     "formatR": {
       "Package": "formatR",
       "Version": "1.11",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "2590a6a868515a69f258640a51b724c9"
+      "Repository": "CRAN",
+      "Hash": "2590a6a868515a69f258640a51b724c9",
+      "Requirements": []
     },
     "fs": {
       "Package": "fs",
-      "Version": "1.5.0",
+      "Version": "1.5.2",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "44594a07a42e5f91fac9f93fda6d0109"
+      "Repository": "CRAN",
+      "Hash": "7c89603d81793f0d5486d91ab1fc6f1d",
+      "Requirements": []
     },
     "generics": {
       "Package": "generics",
       "Version": "0.1.1",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "3f6bcfb0ee5d671d9fd1893d2faa79cb"
+      "Repository": "CRAN",
+      "Hash": "3f6bcfb0ee5d671d9fd1893d2faa79cb",
+      "Requirements": []
     },
     "ggplot2": {
       "Package": "ggplot2",
       "Version": "3.3.5",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "d7566c471c7b17e095dd023b9ef155ad"
+      "Repository": "CRAN",
+      "Hash": "d7566c471c7b17e095dd023b9ef155ad",
+      "Requirements": [
+        "MASS",
+        "digest",
+        "glue",
+        "gtable",
+        "isoband",
+        "mgcv",
+        "rlang",
+        "scales",
+        "tibble",
+        "withr"
+      ]
     },
     "ggrepel": {
       "Package": "ggrepel",
       "Version": "0.9.1",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "08ab869f37e6a7741a64ab9069bcb67d"
+      "Repository": "CRAN",
+      "Hash": "08ab869f37e6a7741a64ab9069bcb67d",
+      "Requirements": [
+        "Rcpp",
+        "ggplot2",
+        "rlang",
+        "scales"
+      ]
     },
     "glue": {
       "Package": "glue",
-      "Version": "1.5.0",
+      "Version": "1.6.0",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "5ccb956a6d09b4ca448094582f8c7571"
+      "Repository": "CRAN",
+      "Hash": "b8bb7aaf248e45bac08ebed86f3a0aa4",
+      "Requirements": []
     },
     "gridExtra": {
       "Package": "gridExtra",
       "Version": "2.3",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "7d7f283939f563670a697165b2cf5560"
+      "Repository": "CRAN",
+      "Hash": "7d7f283939f563670a697165b2cf5560",
+      "Requirements": [
+        "gtable"
+      ]
     },
     "gsDesign": {
       "Package": "gsDesign",
       "Version": "3.2.1",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "7e205a1cda23528a18d8037053947ce6"
+      "Repository": "CRAN",
+      "Hash": "7e205a1cda23528a18d8037053947ce6",
+      "Requirements": [
+        "dplyr",
+        "ggplot2",
+        "magrittr",
+        "rlang",
+        "tidyr",
+        "xtable"
+      ]
     },
     "gsDesign2": {
       "Package": "gsDesign2",
       "Version": "0.1.0",
       "Source": "GitHub",
+      "Remotes": "Merck/simtrial",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
-      "RemoteUsername": "merck",
       "RemoteRepo": "gsDesign2",
-      "RemoteRef": "main",
-      "RemoteSha": "371ac84480ceb38b6e99c3b4b4ad803fa657810e",
-      "Remotes": "Merck/simtrial",
-      "Hash": "d567e6ab718cd6ac8ebab0492a98e5d8"
+      "RemoteUsername": "Merck",
+      "RemoteRef": "HEAD",
+      "RemoteSha": "fc3a2d34c49e801f4e251644fae980be49aa79f6",
+      "Hash": "73d01801983e67668ed344b87ea4af8a",
+      "Requirements": [
+        "dplyr",
+        "tibble"
+      ]
     },
     "gsdmvn": {
       "Package": "gsdmvn",
       "Version": "0.1.1.9000",
       "Source": "GitHub",
+      "Remotes": "Merck/simtrial, Merck/gsDesign2",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
-      "RemoteUsername": "merck",
       "RemoteRepo": "gsdmvn",
-      "RemoteRef": "main",
-      "RemoteSha": "af34897bb307873b0a23145911c9c89d6d5f31c1",
-      "Remotes": "Merck/simtrial, Merck/gsDesign2",
-      "Hash": "d5f4e40abc49ea5999141fe747c64218"
+      "RemoteUsername": "Merck",
+      "RemoteRef": "HEAD",
+      "RemoteSha": "ef2bb74452debeb86327b4e0269ca01f5e29cf5e",
+      "Hash": "6f886690b35c57fc39e651ebd7e8b3c4",
+      "Requirements": [
+        "corpcor",
+        "dplyr",
+        "gsDesign",
+        "gsDesign2",
+        "mvtnorm",
+        "npsurvSS",
+        "tibble"
+      ]
     },
     "gt": {
       "Package": "gt",
       "Version": "0.3.1",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "e027761c361e66a24e22f9446b3dd86c"
+      "Repository": "CRAN",
+      "Hash": "e027761c361e66a24e22f9446b3dd86c",
+      "Requirements": [
+        "base64enc",
+        "bitops",
+        "checkmate",
+        "commonmark",
+        "dplyr",
+        "fs",
+        "ggplot2",
+        "glue",
+        "htmltools",
+        "magrittr",
+        "rlang",
+        "sass",
+        "scales",
+        "stringr",
+        "tibble",
+        "tidyselect"
+      ]
     },
     "gtable": {
       "Package": "gtable",
       "Version": "0.3.0",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "ac5c6baf7822ce8732b343f14c072c4d"
+      "Repository": "CRAN",
+      "Hash": "ac5c6baf7822ce8732b343f14c072c4d",
+      "Requirements": []
     },
     "highr": {
       "Package": "highr",
       "Version": "0.9",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "8eb36c8125038e648e5d111c0d7b2ed4"
+      "Repository": "CRAN",
+      "Hash": "8eb36c8125038e648e5d111c0d7b2ed4",
+      "Requirements": [
+        "xfun"
+      ]
     },
     "htmltools": {
       "Package": "htmltools",
       "Version": "0.5.2",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "526c484233f42522278ab06fb185cb26"
+      "Repository": "CRAN",
+      "Hash": "526c484233f42522278ab06fb185cb26",
+      "Requirements": [
+        "base64enc",
+        "digest",
+        "fastmap",
+        "rlang"
+      ]
     },
     "httr": {
       "Package": "httr",
       "Version": "1.4.2",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "a525aba14184fec243f9eaec62fbed43"
+      "Repository": "CRAN",
+      "Hash": "a525aba14184fec243f9eaec62fbed43",
+      "Requirements": [
+        "R6",
+        "curl",
+        "jsonlite",
+        "mime",
+        "openssl"
+      ]
     },
     "isoband": {
       "Package": "isoband",
       "Version": "0.2.5",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "7ab57a6de7f48a8dc84910d1eca42883"
+      "Repository": "CRAN",
+      "Hash": "7ab57a6de7f48a8dc84910d1eca42883",
+      "Requirements": []
     },
     "jquerylib": {
       "Package": "jquerylib",
       "Version": "0.1.4",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "5aab57a3bd297eee1c1d862735972182"
+      "Repository": "CRAN",
+      "Hash": "5aab57a3bd297eee1c1d862735972182",
+      "Requirements": [
+        "htmltools"
+      ]
     },
     "jsonlite": {
       "Package": "jsonlite",
       "Version": "1.7.2",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "98138e0994d41508c7a6b84a0600cfcb"
+      "Repository": "CRAN",
+      "Hash": "98138e0994d41508c7a6b84a0600cfcb",
+      "Requirements": []
     },
     "kableExtra": {
       "Package": "kableExtra",
       "Version": "1.3.4",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "49b625e6aabe4c5f091f5850aba8ff78"
+      "Repository": "CRAN",
+      "Hash": "49b625e6aabe4c5f091f5850aba8ff78",
+      "Requirements": [
+        "digest",
+        "glue",
+        "htmltools",
+        "knitr",
+        "magrittr",
+        "rmarkdown",
+        "rstudioapi",
+        "rvest",
+        "scales",
+        "stringr",
+        "svglite",
+        "viridisLite",
+        "webshot",
+        "xml2"
+      ]
     },
     "km.ci": {
       "Package": "km.ci",
       "Version": "0.5-2",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "b6090043f6d0b5ffc447be4b3f2811e9"
+      "Repository": "CRAN",
+      "Hash": "b6090043f6d0b5ffc447be4b3f2811e9",
+      "Requirements": [
+        "survival"
+      ]
     },
     "knitr": {
       "Package": "knitr",
-      "Version": "1.36",
+      "Version": "1.37",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "46344b93f8854714cdf476433a59ed10"
+      "Repository": "CRAN",
+      "Hash": "a4ec675eb332a33fe7b7fe26f70e1f98",
+      "Requirements": [
+        "evaluate",
+        "highr",
+        "stringr",
+        "xfun",
+        "yaml"
+      ]
     },
     "labeling": {
       "Package": "labeling",
       "Version": "0.4.2",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "3d5108641f47470611a32d0bdf357a72"
+      "Repository": "CRAN",
+      "Hash": "3d5108641f47470611a32d0bdf357a72",
+      "Requirements": []
     },
     "lattice": {
       "Package": "lattice",
       "Version": "0.20-45",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "b64cdbb2b340437c4ee047a1f4c4377b"
+      "Repository": "CRAN",
+      "Hash": "b64cdbb2b340437c4ee047a1f4c4377b",
+      "Requirements": []
     },
     "lifecycle": {
       "Package": "lifecycle",
       "Version": "1.0.1",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "a6b6d352e3ed897373ab19d8395c98d0"
+      "Repository": "CRAN",
+      "Hash": "a6b6d352e3ed897373ab19d8395c98d0",
+      "Requirements": [
+        "glue",
+        "rlang"
+      ]
     },
     "magrittr": {
       "Package": "magrittr",
       "Version": "2.0.1",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "41287f1ac7d28a92f0a286ed507928d3"
+      "Repository": "CRAN",
+      "Hash": "41287f1ac7d28a92f0a286ed507928d3",
+      "Requirements": []
     },
     "memoise": {
       "Package": "memoise",
-      "Version": "2.0.0",
+      "Version": "2.0.1",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "a0bc51650201a56d00a4798523cc91b3"
+      "Repository": "CRAN",
+      "Hash": "e2817ccf4a065c5d9d7f2cfbe7c1d78c",
+      "Requirements": [
+        "cachem",
+        "rlang"
+      ]
     },
     "mgcv": {
       "Package": "mgcv",
       "Version": "1.8-38",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "be3c61ffbb1e3d3b3df214d192ac5444"
+      "Repository": "CRAN",
+      "Hash": "be3c61ffbb1e3d3b3df214d192ac5444",
+      "Requirements": [
+        "Matrix",
+        "nlme"
+      ]
     },
     "mime": {
       "Package": "mime",
       "Version": "0.12",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "18e9c28c1d3ca1560ce30658b22ce104"
+      "Repository": "CRAN",
+      "Hash": "18e9c28c1d3ca1560ce30658b22ce104",
+      "Requirements": []
     },
     "munsell": {
       "Package": "munsell",
       "Version": "0.5.0",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "6dfe8bf774944bd5595785e3229d8771"
+      "Repository": "CRAN",
+      "Hash": "6dfe8bf774944bd5595785e3229d8771",
+      "Requirements": [
+        "colorspace"
+      ]
     },
     "mvtnorm": {
       "Package": "mvtnorm",
       "Version": "1.1-3",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "7a7541cc284cb2ba3ba7eae645892af5"
+      "Repository": "CRAN",
+      "Hash": "7a7541cc284cb2ba3ba7eae645892af5",
+      "Requirements": []
     },
     "nlme": {
       "Package": "nlme",
       "Version": "3.1-153",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "2d632e0d963a653a0329756ce701ecdd"
+      "Repository": "CRAN",
+      "Hash": "2d632e0d963a653a0329756ce701ecdd",
+      "Requirements": [
+        "lattice"
+      ]
     },
     "npsurvSS": {
       "Package": "npsurvSS",
       "Version": "1.0.1",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "f0d457627c2093a47506f092021b158f"
+      "Repository": "CRAN",
+      "Hash": "f0d457627c2093a47506f092021b158f",
+      "Requirements": []
     },
     "openssl": {
       "Package": "openssl",
-      "Version": "1.4.5",
+      "Version": "1.4.6",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Hash": "5406fd37ef0bf9b88c8a4f264d6ec220"
+      "Hash": "69fdf291af288f32fd4cd93315084ea8",
+      "Requirements": [
+        "askpass"
+      ]
     },
     "pillar": {
       "Package": "pillar",
       "Version": "1.6.4",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "60200b6aa32314ac457d3efbb5ccbd98"
+      "Repository": "CRAN",
+      "Hash": "60200b6aa32314ac457d3efbb5ccbd98",
+      "Requirements": [
+        "cli",
+        "crayon",
+        "ellipsis",
+        "fansi",
+        "lifecycle",
+        "rlang",
+        "utf8",
+        "vctrs"
+      ]
     },
     "pkgconfig": {
       "Package": "pkgconfig",
       "Version": "2.0.3",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "01f28d4278f15c76cddbea05899c5d6f"
-    },
-    "pkglite": {
-      "Package": "pkglite",
-      "Version": "0.2.0",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "10103029c41084775f6f0a839302cdd4"
+      "Repository": "CRAN",
+      "Hash": "01f28d4278f15c76cddbea05899c5d6f",
+      "Requirements": []
     },
     "processx": {
       "Package": "processx",
       "Version": "3.5.2",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "0cbca2bc4d16525d009c4dbba156b37c"
+      "Repository": "CRAN",
+      "Hash": "0cbca2bc4d16525d009c4dbba156b37c",
+      "Requirements": [
+        "R6",
+        "ps"
+      ]
     },
     "ps": {
       "Package": "ps",
       "Version": "1.6.0",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "32620e2001c1dce1af49c49dccbb9420"
+      "Repository": "CRAN",
+      "Hash": "32620e2001c1dce1af49c49dccbb9420",
+      "Requirements": []
     },
     "purrr": {
       "Package": "purrr",
       "Version": "0.3.4",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "97def703420c8ab10d8f0e6c72101e02"
+      "Repository": "CRAN",
+      "Hash": "97def703420c8ab10d8f0e6c72101e02",
+      "Requirements": [
+        "magrittr",
+        "rlang"
+      ]
     },
     "rappdirs": {
       "Package": "rappdirs",
       "Version": "0.3.3",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "5e3c5dc0b071b21fa128676560dbe94d"
-    },
-    "remotes": {
-      "Package": "remotes",
-      "Version": "2.4.1",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "feaca31e417db79fd1832e25b51a7717"
+      "Repository": "CRAN",
+      "Hash": "5e3c5dc0b071b21fa128676560dbe94d",
+      "Requirements": []
     },
     "renv": {
       "Package": "renv",
-      "Version": "0.14.0",
+      "Version": "0.15.2",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "30e5eba91b67f7f4d75d31de14bbfbdc"
+      "Repository": "CRAN",
+      "Hash": "206c4ef8b7ad6fb1060d69aa7b9dfe69",
+      "Requirements": []
     },
     "rlang": {
       "Package": "rlang",
       "Version": "0.4.12",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "0879f5388fe6e4d56d7ef0b7ccb031e5"
+      "Repository": "CRAN",
+      "Hash": "0879f5388fe6e4d56d7ef0b7ccb031e5",
+      "Requirements": []
     },
     "rmarkdown": {
       "Package": "rmarkdown",
       "Version": "2.11",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "320017b52d05a943981272b295750388"
+      "Repository": "CRAN",
+      "Hash": "320017b52d05a943981272b295750388",
+      "Requirements": [
+        "evaluate",
+        "htmltools",
+        "jquerylib",
+        "jsonlite",
+        "knitr",
+        "stringr",
+        "tinytex",
+        "xfun",
+        "yaml"
+      ]
     },
     "rprojroot": {
       "Package": "rprojroot",
       "Version": "2.0.2",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "249d8cd1e74a8f6a26194a91b47f21d1"
+      "Repository": "CRAN",
+      "Hash": "249d8cd1e74a8f6a26194a91b47f21d1",
+      "Requirements": []
     },
     "rstudioapi": {
       "Package": "rstudioapi",
       "Version": "0.13",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "06c85365a03fdaf699966cc1d3cf53ea"
+      "Repository": "CRAN",
+      "Hash": "06c85365a03fdaf699966cc1d3cf53ea",
+      "Requirements": []
     },
     "rvest": {
       "Package": "rvest",
       "Version": "1.0.2",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "bb099886deffecd6f9b298b7d4492943"
+      "Repository": "CRAN",
+      "Hash": "bb099886deffecd6f9b298b7d4492943",
+      "Requirements": [
+        "httr",
+        "lifecycle",
+        "magrittr",
+        "rlang",
+        "selectr",
+        "tibble",
+        "xml2"
+      ]
     },
     "sass": {
       "Package": "sass",
       "Version": "0.4.0",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "50cf822feb64bb3977bda0b7091be623"
+      "Repository": "CRAN",
+      "Hash": "50cf822feb64bb3977bda0b7091be623",
+      "Requirements": [
+        "R6",
+        "fs",
+        "htmltools",
+        "rappdirs",
+        "rlang"
+      ]
     },
     "scales": {
       "Package": "scales",
       "Version": "1.1.1",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "6f76f71042411426ec8df6c54f34e6dd"
+      "Repository": "CRAN",
+      "Hash": "6f76f71042411426ec8df6c54f34e6dd",
+      "Requirements": [
+        "R6",
+        "RColorBrewer",
+        "farver",
+        "labeling",
+        "lifecycle",
+        "munsell",
+        "viridisLite"
+      ]
     },
     "selectr": {
       "Package": "selectr",
       "Version": "0.4-2",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "3838071b66e0c566d55cc26bd6e27bf4"
+      "Repository": "CRAN",
+      "Hash": "3838071b66e0c566d55cc26bd6e27bf4",
+      "Requirements": [
+        "R6",
+        "stringr"
+      ]
     },
     "simtrial": {
       "Package": "simtrial",
       "Version": "0.2.0",
       "Source": "GitHub",
+      "Remotes": "dominicmagirr/modestWLRT",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
-      "RemoteUsername": "merck",
       "RemoteRepo": "simtrial",
-      "RemoteRef": "main",
-      "RemoteSha": "b513e32cbc71ff184e94de4d7d3503fe454ec236",
-      "Remotes": "dominicmagirr/modestWLRT",
-      "Hash": "fa6fb30ca135e7712ed32715e5385199"
+      "RemoteUsername": "Merck",
+      "RemoteRef": "HEAD",
+      "RemoteSha": "87cd828dd5b3f770f5637f4c4a77cc65a6580696",
+      "Hash": "dd17d98aa5f7bc78ec05d50be2a62ea4",
+      "Requirements": [
+        "dplyr",
+        "mvtnorm",
+        "survival",
+        "tibble",
+        "tidyr"
+      ]
     },
     "stringi": {
       "Package": "stringi",
-      "Version": "1.7.5",
+      "Version": "1.7.6",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "cd50dc9b449de3d3b47cdc9976886999"
+      "Repository": "CRAN",
+      "Hash": "bba431031d30789535745a9627ac9271",
+      "Requirements": []
     },
     "stringr": {
       "Package": "stringr",
       "Version": "1.4.0",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "0759e6b6c0957edb1311028a49a35e76"
+      "Repository": "CRAN",
+      "Hash": "0759e6b6c0957edb1311028a49a35e76",
+      "Requirements": [
+        "glue",
+        "magrittr",
+        "stringi"
+      ]
     },
     "survMisc": {
       "Package": "survMisc",
       "Version": "0.5.5",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "566b73db4f3b2f517e707e1c73267325"
+      "Repository": "CRAN",
+      "Hash": "566b73db4f3b2f517e707e1c73267325",
+      "Requirements": [
+        "KMsurv",
+        "data.table",
+        "ggplot2",
+        "gridExtra",
+        "km.ci",
+        "knitr",
+        "survival",
+        "xtable",
+        "zoo"
+      ]
     },
     "survival": {
       "Package": "survival",
       "Version": "3.2-13",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "6f0a0fadc63bc6570fe172770f15bbc4"
+      "Repository": "CRAN",
+      "Hash": "6f0a0fadc63bc6570fe172770f15bbc4",
+      "Requirements": [
+        "Matrix"
+      ]
     },
     "svglite": {
       "Package": "svglite",
       "Version": "2.0.0",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "8fb6188960bf0f90996ce52f9c2106ac"
+      "Repository": "CRAN",
+      "Hash": "8fb6188960bf0f90996ce52f9c2106ac",
+      "Requirements": [
+        "cpp11",
+        "systemfonts"
+      ]
     },
     "sys": {
       "Package": "sys",
       "Version": "3.4",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "b227d13e29222b4574486cfcbde077fa"
+      "Repository": "CRAN",
+      "Hash": "b227d13e29222b4574486cfcbde077fa",
+      "Requirements": []
     },
     "systemfonts": {
       "Package": "systemfonts",
       "Version": "1.0.3",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "5be9fcf8ef6763e8cb13ab009e273a1d"
+      "Repository": "CRAN",
+      "Hash": "5be9fcf8ef6763e8cb13ab009e273a1d",
+      "Requirements": [
+        "cpp11"
+      ]
     },
     "tibble": {
       "Package": "tibble",
       "Version": "3.1.6",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "8a8f02d1934dfd6431c671361510dd0b"
+      "Repository": "CRAN",
+      "Hash": "8a8f02d1934dfd6431c671361510dd0b",
+      "Requirements": [
+        "ellipsis",
+        "fansi",
+        "lifecycle",
+        "magrittr",
+        "pillar",
+        "pkgconfig",
+        "rlang",
+        "vctrs"
+      ]
     },
     "tidyr": {
       "Package": "tidyr",
       "Version": "1.1.4",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "c8fbdbd9fcac223d6c6fe8e406f368e1"
+      "Repository": "CRAN",
+      "Hash": "c8fbdbd9fcac223d6c6fe8e406f368e1",
+      "Requirements": [
+        "cpp11",
+        "dplyr",
+        "ellipsis",
+        "glue",
+        "lifecycle",
+        "magrittr",
+        "purrr",
+        "rlang",
+        "tibble",
+        "tidyselect",
+        "vctrs"
+      ]
     },
     "tidyselect": {
       "Package": "tidyselect",
       "Version": "1.1.1",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "7243004a708d06d4716717fa1ff5b2fe"
+      "Repository": "CRAN",
+      "Hash": "7243004a708d06d4716717fa1ff5b2fe",
+      "Requirements": [
+        "ellipsis",
+        "glue",
+        "purrr",
+        "rlang",
+        "vctrs"
+      ]
     },
     "tinytex": {
       "Package": "tinytex",
-      "Version": "0.35",
+      "Version": "0.36",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "1d7220fe46159fb9f5c99a44354a2bff"
+      "Repository": "CRAN",
+      "Hash": "130fe4c61e55b271a2655b3a284a205f",
+      "Requirements": [
+        "xfun"
+      ]
     },
     "utf8": {
       "Package": "utf8",
       "Version": "1.2.2",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "c9c462b759a5cc844ae25b5942654d13"
+      "Repository": "CRAN",
+      "Hash": "c9c462b759a5cc844ae25b5942654d13",
+      "Requirements": []
     },
     "vctrs": {
       "Package": "vctrs",
       "Version": "0.3.8",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "ecf749a1b39ea72bd9b51b76292261f1"
+      "Repository": "CRAN",
+      "Hash": "ecf749a1b39ea72bd9b51b76292261f1",
+      "Requirements": [
+        "ellipsis",
+        "glue",
+        "rlang"
+      ]
     },
     "viridisLite": {
       "Package": "viridisLite",
       "Version": "0.4.0",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "55e157e2aa88161bdb0754218470d204"
+      "Repository": "CRAN",
+      "Hash": "55e157e2aa88161bdb0754218470d204",
+      "Requirements": []
     },
     "webshot": {
       "Package": "webshot",
       "Version": "0.5.2",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "e99d80ad34457a4853674e89d5e806de"
+      "Repository": "CRAN",
+      "Hash": "e99d80ad34457a4853674e89d5e806de",
+      "Requirements": [
+        "callr",
+        "jsonlite",
+        "magrittr"
+      ]
     },
     "withr": {
       "Package": "withr",
-      "Version": "2.4.2",
+      "Version": "2.4.3",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "ad03909b44677f930fa156d47d7a3aeb"
+      "Repository": "CRAN",
+      "Hash": "a376b424c4817cda4920bbbeb3364e85",
+      "Requirements": []
     },
     "xfun": {
       "Package": "xfun",
-      "Version": "0.28",
+      "Version": "0.29",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "f7f3a61ab62cd046d307577a8ae12999"
+      "Repository": "CRAN",
+      "Hash": "e2e5fb1a74fbb68b27d6efc5372635dc",
+      "Requirements": []
     },
     "xml2": {
       "Package": "xml2",
-      "Version": "1.3.2",
+      "Version": "1.3.3",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "d4d71a75dd3ea9eb5fa28cc21f9585e2"
+      "Repository": "CRAN",
+      "Hash": "40682ed6a969ea5abfd351eb67833adc",
+      "Requirements": []
     },
     "xtable": {
       "Package": "xtable",
       "Version": "1.8-4",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "b8acdf8af494d9ec19ccb2481a9b11c2"
+      "Repository": "CRAN",
+      "Hash": "b8acdf8af494d9ec19ccb2481a9b11c2",
+      "Requirements": []
     },
     "yaml": {
       "Package": "yaml",
       "Version": "2.2.1",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "2826c5d9efb0a88f657c7a679c7106db"
+      "Repository": "CRAN",
+      "Hash": "2826c5d9efb0a88f657c7a679c7106db",
+      "Requirements": []
     },
     "zoo": {
       "Package": "zoo",
       "Version": "1.8-9",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "035d1c7c12593038c26fb1c2fd40c4d2"
+      "Repository": "CRAN",
+      "Hash": "035d1c7c12593038c26fb1c2fd40c4d2",
+      "Requirements": [
+        "lattice"
+      ]
     }
   }
 }


### PR DESCRIPTION
This PR mainly fixes the bookdown build issue:

```
Error in loadNamespace(x) : there is no package called ‘bookdown’
```

Also comes with a bonus bib file fix.

## What's changed

- Update `renv.lock`
- Install libcurl requird by the R package curl in the bookdown workflow.
- Sort the bib file alphabetically using the VS Code extension "LaTeX Workshop". This helps identify and remove a few duplicated bib items (same paper with the same ID) and disambiguated a pair of two different papers but with the same id (luo2019design -> luo2019design, luo2019rmst).

The build passes reliably in my forked repo.
